### PR TITLE
Fix map free-draw refresh and clearing bugs

### DIFF
--- a/src/components/map/map-draw-control.tsx
+++ b/src/components/map/map-draw-control.tsx
@@ -116,7 +116,7 @@ const MapDrawControl = () => {
                 });
                 map.addLayer(freeDraw);
 
-                freeDraw.on('markers', (event: any) => {
+                const handleMarkers = (event: any) => {
                     // event.latLngs contains an array for each drawn shape.
                     // Convert each shape into a polyline and clear the FreeDraw layer
                     // so shapes don't persist internally.
@@ -135,8 +135,12 @@ const MapDrawControl = () => {
 
                     // Remove the drawn shape from FreeDraw's internal layer to
                     // prevent old drawings from reappearing on subsequent draws.
+                    freeDraw.off('markers', handleMarkers);
                     freeDraw.clear();
-                });
+                    freeDraw.on('markers', handleMarkers);
+                };
+
+                freeDraw.on('markers', handleMarkers);
                 drawer = freeDraw;
                 freeDrawRef.current = freeDraw;
                 break;


### PR DESCRIPTION
## Summary
- Ensure FreeDraw shapes render immediately and clear internal layers after each draw
- Clear FreeDraw internal state when "Clear All" is used

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a42f95d0a4832aa4c8a55db6913610