### PR TITLE
feat: support base presets for textarea narratives

### DIFF
--- a/data/paperwork-generators/warrant-affidavit.json
+++ b/data/paperwork-generators/warrant-affidavit.json
@@ -24,31 +24,32 @@
             "name": "narrative",
             "label": "Affidavit Narrative",
             "noLocalStorage": true,
+            "preset": "{{modifiers.introduction}}\n\n{{modifiers.submission_statement}}\n\n{{modifiers.probable_cause}}\n\n{{modifiers.scope_of_request}}\n\n{{modifiers.conclusion}}",
             "modifiers": [
                 {
                     "name": "introduction",
                     "label": "Affiant Introduction",
-                    "generateText": "I, {{officers.0.rank}} {{officers.0.name}} (#{{officers.0.badgeNumber}}), am a peace officer employed with the {{officers.0.department}}, currently assigned to the {{officers.0.divDetail}}. I have been employed by this agency for [X] years and have extensive experience in [briefly describe experience, e.g., narcotics investigations, homicide, etc.]."
+                    "text": "I, {{officers.0.rank}} {{officers.0.name}} (#{{officers.0.badgeNumber}}), am a peace officer employed with the {{officers.0.department}}, currently assigned to the {{officers.0.divDetail}}. I have been employed by this agency for [X] years and have extensive experience in [briefly describe experience, e.g., narcotics investigations, homicide, etc.]."
                 },
                 {
                     "name": "submission_statement",
                     "label": "Submission Statement",
-                    "generateText": "I submit this affidavit in support of an {{warrant_type}} for [SUBJECT/LOCATION]. This request is based on an ongoing investigation into [CRIME(S)] (Casefile #XXXXXX)."
+                    "text": "I submit this affidavit in support of an {{warrant_type}} for [SUBJECT/LOCATION]. This request is based on an ongoing investigation into [CRIME(S)] (Casefile #XXXXXX)."
                 },
                 {
                     "name": "probable_cause",
                     "label": "Probable Cause Statement",
-                    "generateText": "The following facts establish probable cause for this warrant:\nOn [DATE] at approximately [TIME], [Describe initial event or discovery]. This was followed by [Describe subsequent investigative steps, e.g., witness interviews, evidence collection, surveillance]. Evidence gathered, including [mention key evidence like informant tips, physical evidence, or preliminary forensic results], indicates that [explain what the evidence shows and how it links the subject/location to the crime]."
+                    "text": "The following facts establish probable cause for this warrant:\nOn [DATE] at approximately [TIME], [Describe initial event or discovery]. This was followed by [Describe subsequent investigative steps, e.g., witness interviews, evidence collection, surveillance]. Evidence gathered, including [mention key evidence like informant tips, physical evidence, or preliminary forensic results], indicates that [explain what the evidence shows and how it links the subject/location to the crime]."
                 },
                 {
                     "name": "scope_of_request",
                     "label": "Scope of Request",
-                    "generateText": "Based on the probable cause outlined above, I request authorization to [search/arrest/monitor] the following:\n1. [SPECIFIC LOCATION/PERSON/VEHICLE/DEVICE]: I seek to seize [SPECIFIC ITEMS TO BE SEIZED, e.g., firearms, narcotics, financial records, electronic devices].\n2. [ADDITIONAL LOCATIONS/ITEMS AS NEEDED]"
+                    "text": "Based on the probable cause outlined above, I request authorization to [search/arrest/monitor] the following:\n1. [SPECIFIC LOCATION/PERSON/VEHICLE/DEVICE]: I seek to seize [SPECIFIC ITEMS TO BE SEIZED, e.g., firearms, narcotics, financial records, electronic devices].\n2. [ADDITIONAL LOCATIONS/ITEMS AS NEEDED]"
                 },
                 {
                     "name": "conclusion",
                     "label": "Conclusion",
-                    "generateText": "Based on the information contained in this affidavit, I respectfully request that this court issue the requested {{warrant_type}}.\n\nI declare under penalty of perjury that the foregoing is true and correct.\n\n{{officers.0.name}}\n{{officers.0.rank}}\n{{officers.0.department}}\nDATED: {{general.date}}"
+                    "text": "Based on the information contained in this affidavit, I respectfully request that this court issue the requested {{warrant_type}}.\n\nI declare under penalty of perjury that the foregoing is true and correct.\n\n{{officers.0.name}}\n{{officers.0.rank}}\n{{officers.0.department}}\nDATED: {{general.date}}"
                 }
             ]
         }

--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -12,6 +12,8 @@ import { Separator } from '../ui/separator';
 export type Modifier = {
     name: string;
     label: string;
+    text?: string;
+    requires?: string[];
 };
 
 interface TextareaWithPresetProps {

--- a/src/stores/basic-report-modifiers-store.ts
+++ b/src/stores/basic-report-modifiers-store.ts
@@ -6,7 +6,8 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 export type Modifier = {
     name: string;
     label: string;
-    generateText: () => string;
+    text?: string;
+    requires?: string[];
 };
 
 type ModifiersState = Record<string, boolean>;
@@ -28,7 +29,7 @@ interface BasicReportModifiersState {
 
 const getInitialState = (): Omit<BasicReportModifiersState, 'setModifier' | 'setPreset' | 'setUserModified' | 'setNarrativeField' | 'reset'> => ({
     modifiers: {
-        introduction: true,
+        call_of_service: false,
     },
     presets: {
         narrative: true,


### PR DESCRIPTION
## Summary
- allow textarea-with-preset to define modifier text and dependencies
- add base preset generation to arrest report with "Call of Service" modifier
- enable preset templates in paperwork generator and warrant affidavit config

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck` *(fails: Type 'null' is not assignable to type 'string | undefined', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c54b7f54832aad86e45c87ec617e