### PR TITLE
feat: support base presets for textarea narratives

### DIFF
--- a/data/paperwork-generators/warrant-affidavit.json
+++ b/data/paperwork-generators/warrant-affidavit.json
@@ -24,31 +24,32 @@
             "name": "narrative",
             "label": "Affidavit Narrative",
             "noLocalStorage": true,
+            "preset": "{{modifiers.introduction}}\n\n{{modifiers.submission_statement}}\n\n{{modifiers.probable_cause}}\n\n{{modifiers.scope_of_request}}\n\n{{modifiers.conclusion}}",
             "modifiers": [
                 {
                     "name": "introduction",
                     "label": "Affiant Introduction",
-                    "generateText": "I, {{officers.0.rank}} {{officers.0.name}} (#{{officers.0.badgeNumber}}), am a peace officer employed with the {{officers.0.department}}, currently assigned to the {{officers.0.divDetail}}. I have been employed by this agency for [X] years and have extensive experience in [briefly describe experience, e.g., narcotics investigations, homicide, etc.]."
+                    "text": "I, {{officers.0.rank}} {{officers.0.name}} (#{{officers.0.badgeNumber}}), am a peace officer employed with the {{officers.0.department}}, currently assigned to the {{officers.0.divDetail}}. I have been employed by this agency for [X] years and have extensive experience in [briefly describe experience, e.g., narcotics investigations, homicide, etc.]."
                 },
                 {
                     "name": "submission_statement",
                     "label": "Submission Statement",
-                    "generateText": "I submit this affidavit in support of an {{warrant_type}} for [SUBJECT/LOCATION]. This request is based on an ongoing investigation into [CRIME(S)] (Casefile #XXXXXX)."
+                    "text": "I submit this affidavit in support of an {{warrant_type}} for [SUBJECT/LOCATION]. This request is based on an ongoing investigation into [CRIME(S)] (Casefile #XXXXXX)."
                 },
                 {
                     "name": "probable_cause",
                     "label": "Probable Cause Statement",
-                    "generateText": "The following facts establish probable cause for this warrant:\nOn [DATE] at approximately [TIME], [Describe initial event or discovery]. This was followed by [Describe subsequent investigative steps, e.g., witness interviews, evidence collection, surveillance]. Evidence gathered, including [mention key evidence like informant tips, physical evidence, or preliminary forensic results], indicates that [explain what the evidence shows and how it links the subject/location to the crime]."
+                    "text": "The following facts establish probable cause for this warrant:\nOn [DATE] at approximately [TIME], [Describe initial event or discovery]. This was followed by [Describe subsequent investigative steps, e.g., witness interviews, evidence collection, surveillance]. Evidence gathered, including [mention key evidence like informant tips, physical evidence, or preliminary forensic results], indicates that [explain what the evidence shows and how it links the subject/location to the crime]."
                 },
                 {
                     "name": "scope_of_request",
                     "label": "Scope of Request",
-                    "generateText": "Based on the probable cause outlined above, I request authorization to [search/arrest/monitor] the following:\n1. [SPECIFIC LOCATION/PERSON/VEHICLE/DEVICE]: I seek to seize [SPECIFIC ITEMS TO BE SEIZED, e.g., firearms, narcotics, financial records, electronic devices].\n2. [ADDITIONAL LOCATIONS/ITEMS AS NEEDED]"
+                    "text": "Based on the probable cause outlined above, I request authorization to [search/arrest/monitor] the following:\n1. [SPECIFIC LOCATION/PERSON/VEHICLE/DEVICE]: I seek to seize [SPECIFIC ITEMS TO BE SEIZED, e.g., firearms, narcotics, financial records, electronic devices].\n2. [ADDITIONAL LOCATIONS/ITEMS AS NEEDED]"
                 },
                 {
                     "name": "conclusion",
                     "label": "Conclusion",
-                    "generateText": "Based on the information contained in this affidavit, I respectfully request that this court issue the requested {{warrant_type}}.\n\nI declare under penalty of perjury that the foregoing is true and correct.\n\n{{officers.0.name}}\n{{officers.0.rank}}\n{{officers.0.department}}\nDATED: {{general.date}}"
+                    "text": "Based on the information contained in this affidavit, I respectfully request that this court issue the requested {{warrant_type}}.\n\nI declare under penalty of perjury that the foregoing is true and correct.\n\n{{officers.0.name}}\n{{officers.0.rank}}\n{{officers.0.department}}\nDATED: {{general.date}}"
                 }
             ]
         }

--- a/src/components/arrest-report/arrest-report-form.tsx
+++ b/src/components/arrest-report/arrest-report-form.tsx
@@ -29,6 +29,7 @@ import { LocationDetails } from '../shared/location-details';
 import { useForm, FormProvider } from 'react-hook-form';
 import { useBasicReportModifiersStore, Modifier } from '@/stores/basic-report-modifiers-store';
 import { TextareaWithPreset } from '../shared/textarea-with-preset';
+import Handlebars from 'handlebars';
 
 const FormSection = ({
   title,
@@ -149,7 +150,7 @@ export const ArrestReportForm = forwardRef((props, ref) => {
     defaultValues: {
       ...formData,
       narrative: {
-        modifiers: { introduction: modifierState.introduction },
+        modifiers: { call_of_service: modifierState.call_of_service },
         isPreset: presets.narrative,
         userModified: userModified.narrative,
         narrative: narrative.narrative,
@@ -160,11 +161,13 @@ export const ArrestReportForm = forwardRef((props, ref) => {
 
   const formRef = useRef<HTMLFormElement>(null);
   const allWatchedFields = watch();
+  const narrativeValues = watch('narrative');
 
-  const arrestReportModifiers: Omit<Modifier, 'generateText'>[] = useMemo(() => [
+  const arrestReportModifiers: Modifier[] = useMemo(() => [
     {
-        name: 'introduction',
-        label: 'Arrest Report Introduction',
+        name: 'call_of_service',
+        label: 'Call of Service',
+        text: 'received a call of service #',
     }
   ], []);
 
@@ -177,17 +180,31 @@ export const ArrestReportForm = forwardRef((props, ref) => {
         return narrativeValues?.narrative || '';
     }
 
-    let text = '';
     const { general, location, arrest } = allWatchedFields;
     const primaryOfficer = officers[0];
 
-    if (narrativeValues?.modifiers?.introduction && primaryOfficer) {
-        const { date, time } = general;
-        const { street } = location;
-        const { suspectName } = arrest;
-        text += `On the ${date || ''}, I ${primaryOfficer.rank || ''} ${primaryOfficer.name || ''} of the ${primaryOfficer.department || ''} conducted an arrest on ${suspectName || ''}. At approximately ${time || ''} hours, I was driving on ${street || ''} where I `;
+    const modifiersContext: Record<string, string> = {};
+
+    if (narrativeValues?.modifiers?.call_of_service) {
+        modifiersContext.call_of_service = 'received a call of service #';
+    } else {
+        modifiersContext.call_of_service = '';
     }
-    return text;
+
+    const basePreset = 'On the {{date}}, I {{rank}} {{name}} of the {{department}} conducted an arrest on {{suspect}}. At approximately {{time}} hours, I was driving on {{street}} when I {{call_of_service}}';
+
+    const template = Handlebars.compile(basePreset, { noEscape: true });
+
+    return template({
+        date: general.date || '',
+        time: general.time || '',
+        street: location.street || '',
+        suspect: arrest.suspectName || '',
+        rank: primaryOfficer?.rank || '',
+        name: primaryOfficer?.name || '',
+        department: primaryOfficer?.department || '',
+        ...modifiersContext,
+    });
   }, [allWatchedFields, officers]);
 
 
@@ -195,14 +212,24 @@ export const ArrestReportForm = forwardRef((props, ref) => {
     const mergedData = {
       ...formData,
       narrative: {
-        modifiers: { introduction: modifierState.introduction },
+        modifiers: { call_of_service: modifierState.call_of_service },
         isPreset: presets.narrative,
         userModified: userModified.narrative,
         narrative: narrative.narrative,
       },
     };
     reset(mergedData);
-  }, [formData, modifierState.introduction, presets.narrative, userModified.narrative, narrative.narrative, reset]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formData, modifierState, presets, userModified, narrative, reset]);
+
+  useEffect(() => {
+    setModifier('call_of_service', narrativeValues?.modifiers?.call_of_service ?? false);
+    setPreset('narrative', narrativeValues?.isPreset ?? false);
+    setUserModified('narrative', narrativeValues?.userModified ?? false);
+    if (narrativeValues?.userModified) {
+        setNarrativeField('narrative', narrativeValues.narrative);
+    }
+  }, [narrativeValues, setModifier, setPreset, setUserModified, setNarrativeField]);
 
 
   const getFormData = () => {

--- a/src/components/arrest-report/arrest-report-form.tsx
+++ b/src/components/arrest-report/arrest-report-form.tsx
@@ -219,17 +219,40 @@ export const ArrestReportForm = forwardRef((props, ref) => {
       },
     };
     reset(mergedData);
+    // intentionally only run on mount and when formData changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formData, modifierState, presets, userModified, narrative, reset]);
+  }, [formData, reset]);
 
   useEffect(() => {
-    setModifier('call_of_service', narrativeValues?.modifiers?.call_of_service ?? false);
-    setPreset('narrative', narrativeValues?.isPreset ?? false);
-    setUserModified('narrative', narrativeValues?.userModified ?? false);
-    if (narrativeValues?.userModified) {
-        setNarrativeField('narrative', narrativeValues.narrative);
+    const currentCallOfService = narrativeValues?.modifiers?.call_of_service ?? false;
+    if (modifierState.call_of_service !== currentCallOfService) {
+      setModifier('call_of_service', currentCallOfService);
     }
-  }, [narrativeValues, setModifier, setPreset, setUserModified, setNarrativeField]);
+
+    const currentPreset = narrativeValues?.isPreset ?? false;
+    if (presets.narrative !== currentPreset) {
+      setPreset('narrative', currentPreset);
+    }
+
+    const currentUserModified = narrativeValues?.userModified ?? false;
+    if (userModified.narrative !== currentUserModified) {
+      setUserModified('narrative', currentUserModified);
+    }
+
+    if (currentUserModified && narrative.narrative !== narrativeValues?.narrative) {
+      setNarrativeField('narrative', narrativeValues?.narrative ?? '');
+    }
+  }, [
+    narrativeValues,
+    modifierState,
+    presets,
+    userModified,
+    narrative,
+    setModifier,
+    setPreset,
+    setUserModified,
+    setNarrativeField,
+  ]);
 
 
   const getFormData = () => {

--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -1,6 +1,6 @@
 
 'use client';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Control, Controller, useFormContext } from 'react-hook-form';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
@@ -12,6 +12,8 @@ import { Separator } from '../ui/separator';
 export type Modifier = {
     name: string;
     label: string;
+    text?: string;
+    requires?: string[];
 };
 
 interface TextareaWithPresetProps {
@@ -41,6 +43,12 @@ export function TextareaWithPreset({
 
     const isPresetEnabled = watch(`${basePath}.isPreset`);
     const isUserModified = watch(`${basePath}.userModified`);
+
+    useEffect(() => {
+        if (isPresetEnabled && !isUserModified) {
+            setValue(`${basePath}.narrative`, value);
+        }
+    }, [value, isPresetEnabled, isUserModified, basePath, setValue]);
     
     const handleTogglePreset = () => {
         const newValue = !isPresetEnabled;

--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -46,9 +46,12 @@ export function TextareaWithPreset({
 
     useEffect(() => {
         if (isPresetEnabled && !isUserModified) {
-            setValue(`${basePath}.narrative`, value);
+            const current = watch(`${basePath}.narrative`);
+            if (current !== value) {
+                setValue(`${basePath}.narrative`, value);
+            }
         }
-    }, [value, isPresetEnabled, isUserModified, basePath, setValue]);
+    }, [value, isPresetEnabled, isUserModified, basePath, setValue, watch]);
     
     const handleTogglePreset = () => {
         const newValue = !isPresetEnabled;

--- a/src/stores/basic-report-modifiers-store.ts
+++ b/src/stores/basic-report-modifiers-store.ts
@@ -6,7 +6,8 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 export type Modifier = {
     name: string;
     label: string;
-    generateText: () => string;
+    text?: string;
+    requires?: string[];
 };
 
 type ModifiersState = Record<string, boolean>;
@@ -28,7 +29,7 @@ interface BasicReportModifiersState {
 
 const getInitialState = (): Omit<BasicReportModifiersState, 'setModifier' | 'setPreset' | 'setUserModified' | 'setNarrativeField' | 'reset'> => ({
     modifiers: {
-        introduction: true,
+        call_of_service: false,
     },
     presets: {
         narrative: true,


### PR DESCRIPTION
## Summary
- preserve selected narrative modifiers when editing arrest report fields
- recompute preset text areas as generator fields change
- sync computed preset text with form state
- keep narrative modifiers intact when updating other arrest report fields

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck` *(fails: Type 'null' is not assignable to type 'string | undefined', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c54b7f54832aad86e45c87ec617e