### PR TITLE
Refresh textarea presets when dependent fields change

### DIFF
--- a/data/paperwork-generators/warrant-affidavit.json
+++ b/data/paperwork-generators/warrant-affidavit.json
@@ -24,6 +24,7 @@
             "name": "narrative",
             "label": "Affidavit Narrative",
             "noLocalStorage": true,
+            "refreshOn": ["officers", "general"],
             "preset": "{{modifiers.introduction}}\n\n{{modifiers.submission_statement}}\n\n{{modifiers.probable_cause}}\n\n{{modifiers.scope_of_request}}\n\n{{modifiers.conclusion}}",
             "modifiers": [
                 {

--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -67,6 +67,7 @@ type FormField = {
     modifiers?: any[];
     preset?: string;
     noLocalStorage?: boolean;
+    refreshOn?: string[];
 };
 
 type GeneratorConfig = {
@@ -121,6 +122,9 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
         defaultValues: buildDefaultValues(generatorConfig.form)
     });
     const { register, handleSubmit, control, watch, trigger, getValues } = methods;
+
+    const officers = useOfficerStore(state => state.officers);
+    const generalData = useBasicFormStore(state => state.formData.general);
 
     const { setGeneratorData, setFormData, reset } = usePaperworkStore();
     const { toast } = useToast();
@@ -281,10 +285,14 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                     }
 
                     const allData = watch();
-                    const { officers } = useOfficerStore.getState();
-                    const { general } = useBasicFormStore.getState().formData;
+                    const externalData: any = {};
 
-                    const dataForHandlebars: any = { ...allData, officers, general, modifiers: {} };
+                    (field.refreshOn || []).forEach(dep => {
+                        if (dep === 'officers') externalData.officers = officers;
+                        else if (dep === 'general') externalData.general = generalData;
+                    });
+
+                    const dataForHandlebars: any = { ...allData, ...externalData, modifiers: {} };
 
                     (field.modifiers || []).forEach(mod => {
                         const isEnabled = watch(`${path}.modifiers.${mod.name}`);


### PR DESCRIPTION
## Summary
- allow textarea presets to declare `refreshOn` dependencies
- recompute preset narrative when external officer/general data changes
- update warrant affidavit generator to refresh narrative on officer or general edits

## Testing
- `npm run lint` *(fails: configuration prompt)*
- `npm run typecheck` *(fails: Type 'null' is not assignable to type 'string | undefined', and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e71c4618832ab8399f3deac46646