### PR TITLE
Highlight required form fields with red outline

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,6 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         type={type}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "invalid:border-red-500 invalid:focus-visible:ring-red-500",
           className
         )}
         ref={ref}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 data-[placeholder]:border-red-500 data-[placeholder]:focus:ring-red-500",
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,6 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'tex
       <textarea
         className={cn(
           'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'invalid:border-red-500 invalid:focus-visible:ring-red-500',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- Add invalid state styling so required inputs and textareas show a red outline until filled
- Extend select trigger styling to mark empty required selections in red

## Testing
- `npm run lint` *(fails: interactive configuration prompt)*
- `npm run typecheck` *(fails: cannot find module 'next-themes/dist/types'; multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f2c3e424832ab5f7f4b17744bb37