### PR TITLE
Highlight required fields on load

### DIFF
--- a/src/components/arrest-report/arrest-report-form.tsx
+++ b/src/components/arrest-report/arrest-report-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import { useState, useRef, forwardRef, useImperativeHandle, useEffect, useMemo } from 'react';
+import { useRef, forwardRef, useImperativeHandle, useEffect, useMemo } from 'react';
 import {
   Card,
   CardContent,
@@ -57,7 +57,6 @@ const InputField = ({
   className = '',
   defaultValue,
   required = true,
-  isInvalid = false,
   ...props
 }: {
   label: string;
@@ -68,7 +67,6 @@ const InputField = ({
   className?: string;
   defaultValue?: string;
   required?: boolean;
-  isInvalid?: boolean;
 }) => (
   <div className="grid gap-2">
     <Label htmlFor={id}>{label}</Label>
@@ -79,11 +77,7 @@ const InputField = ({
         name={id}
         type={type}
         placeholder={placeholder}
-        className={cn(
-          'pl-9',
-          isInvalid && 'border-red-500 focus-visible:ring-red-500',
-          className
-        )}
+        className={cn('pl-9', className)}
         defaultValue={defaultValue}
         required={required}
         {...props}
@@ -101,7 +95,6 @@ const TextareaField = ({
   className = '',
   defaultValue,
   required = true,
-  isInvalid = false,
   ...props
 }: {
   label: string;
@@ -112,25 +105,20 @@ const TextareaField = ({
   className?: string;
   defaultValue?: string;
   required?: boolean;
-  isInvalid?: boolean;
 }) => (
   <div className="grid gap-2">
     <Label htmlFor={id}>{label}</Label>
     <div className="relative">
       <div className="absolute left-3 top-3.5">{icon}</div>
-      <Textarea
-        id={id}
-        name={id}
-        placeholder={placeholder}
-        className={cn(
-          'pl-9 pt-3',
-          isInvalid && 'border-red-500 focus-visible:ring-red-500',
-          className
-        )}
-        defaultValue={defaultValue}
-        required={required}
-        {...props}
-      />
+        <Textarea
+          id={id}
+          name={id}
+          placeholder={placeholder}
+          className={cn('pl-9 pt-3', className)}
+          defaultValue={defaultValue}
+          required={required}
+          {...props}
+        />
     </div>
     {description && <p className="text-xs text-muted-foreground">{description}</p>}
   </div>
@@ -153,8 +141,6 @@ export const ArrestReportForm = forwardRef((props, ref) => {
     setUserModified,
     setNarrativeField,
   } = useBasicReportModifiersStore();
-
-  const [submitted, setSubmitted] = useState(false);
 
   // RHF
   const methods = useForm({
@@ -372,7 +358,6 @@ export const ArrestReportForm = forwardRef((props, ref) => {
 
   const handleSubmitForm = (e: React.FormEvent) => {
     e.preventDefault();
-    setSubmitted(true);
     const latestFormData = getFormData();
     if (!latestFormData) return;
 
@@ -393,15 +378,14 @@ export const ArrestReportForm = forwardRef((props, ref) => {
   return (
     <FormProvider {...methods}>
       <form ref={formRef} onSubmit={handleSubmitForm} className="space-y-6">
-        <GeneralSection isSubmitted={submitted} />
-        <OfficerSection isSubmitted={submitted} isArrestReport={true} />
+        <GeneralSection />
+        <OfficerSection isArrestReport={true} />
 
         <FormSection title="Location Details" icon={<MapPin className="h-6 w-6" />}>
           <LocationDetails
             districtFieldName="location.district"
             streetFieldName="location.street"
             showDistrict={true}
-            isSubmitted={submitted}
           />
         </FormSection>
 
@@ -414,7 +398,6 @@ export const ArrestReportForm = forwardRef((props, ref) => {
               icon={<User className="h-4 w-4 text-muted-foreground" />}
               defaultValue={formData.arrest?.suspectName ?? ''}
               onBlur={(e) => setFormField('arrest', 'suspectName', e.target.value)}
-              isInvalid={submitted && !formData.arrest?.suspectName}
             />
             <TextareaWithPreset
               label="Arrest Narrative"
@@ -428,7 +411,7 @@ export const ArrestReportForm = forwardRef((props, ref) => {
               basePath="narrative"
               control={control}
               modifiers={arrestReportModifiers}
-              isInvalid={submitted && !allWatchedFields.narrative?.narrative}
+              isInvalid={!allWatchedFields.narrative?.narrative}
               value={narrativeText}
             />
           </div>
@@ -462,7 +445,6 @@ export const ArrestReportForm = forwardRef((props, ref) => {
               className="min-h-[150px]"
               defaultValue={formData.evidence?.dashcam ?? ''}
               onBlur={(e) => setFormField('evidence', 'dashcam', e.target.value)}
-              isInvalid={submitted && !formData.evidence?.dashcam}
             />
           </div>
         </FormSection>

--- a/src/components/arrest-report/general-section.tsx
+++ b/src/components/arrest-report/general-section.tsx
@@ -1,7 +1,7 @@
 
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { formatInTimeZone } from 'date-fns-tz';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
@@ -33,14 +33,13 @@ const InputField = ({
   id,
   placeholder,
   icon,
-  type = 'text',
-  value,
-  onChange,
-  onBlur,
-  readOnly = false,
-  required = true,
-  isInvalid = false,
-}: {
+    type = 'text',
+    value,
+    onChange,
+    onBlur,
+    readOnly = false,
+    required = true,
+  }: {
   label: string;
   id: string;
   placeholder: string;
@@ -50,32 +49,28 @@ const InputField = ({
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   readOnly?: boolean;
-  required?: boolean;
-  isInvalid?: boolean;
-}) => (
+    required?: boolean;
+  }) => (
   <div className="grid gap-2">
     <Label htmlFor={id}>{label}</Label>
     <div className="relative flex items-center">
       <div className="absolute left-2.5 z-10">{icon}</div>
-      <Input
-        id={id}
-        type={type}
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-        readOnly={readOnly}
-        className={cn(
-            'pl-9',
-            isInvalid && 'border-red-500 focus-visible:ring-red-500'
-        )}
-        required={required}
-      />
+        <Input
+          id={id}
+          type={type}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          readOnly={readOnly}
+          className={cn('pl-9')}
+          required={required}
+        />
+      </div>
     </div>
-  </div>
-);
+  );
 
-export function GeneralSection({ isSubmitted }: { isSubmitted: boolean }) {
+export function GeneralSection() {
     const { general, setFormField } = useFormStore(state => ({
         general: state.formData.general,
         setFormField: state.setFormField,
@@ -97,38 +92,37 @@ export function GeneralSection({ isSubmitted }: { isSubmitted: boolean }) {
 
   return (
     <FormSection title="General Section" icon={<CalendarDays className="h-6 w-6" />}>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-        <InputField
-          label="Date"
-          id="date"
-          placeholder="DD/MMM/YYYY"
-          icon={<CalendarDays className="h-4 w-4 text-muted-foreground" />}
-          type="text"
-          value={general?.date || ''}
-          onChange={(e) => setFormField('general', 'date', e.target.value)}
-          onBlur={(e) => setFormField('general', 'date', e.target.value)}
-        />
-        <InputField
-          label="Time"
-          id="time"
-          placeholder="HH:MM"
-          icon={<Clock className="h-4 w-4 text-muted-foreground" />}
-          type="text"
-          value={general?.time || ''}
-          onChange={(e) => setFormField('general', 'time', e.target.value)}
-          onBlur={(e) => setFormField('general', 'time', e.target.value)}
-        />
-        <InputField
-          label="Call Sign"
-          id="call-sign"
-          placeholder="CALL SIGN"
-          icon={<Radio className="h-4 w-4 text-muted-foreground" />}
-          value={general?.callSign || ''}
-          onChange={(e) => setFormField('general', 'callSign', e.target.value)}
-          onBlur={(e) => setFormField('general', 'callSign', e.target.value)}
-          isInvalid={isSubmitted && !general.callSign}
-        />
-      </div>
-    </FormSection>
-  );
-}
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+          <InputField
+            label="Date"
+            id="date"
+            placeholder="DD/MMM/YYYY"
+            icon={<CalendarDays className="h-4 w-4 text-muted-foreground" />}
+            type="text"
+            value={general?.date || ''}
+            onChange={(e) => setFormField('general', 'date', e.target.value)}
+            onBlur={(e) => setFormField('general', 'date', e.target.value)}
+          />
+          <InputField
+            label="Time"
+            id="time"
+            placeholder="HH:MM"
+            icon={<Clock className="h-4 w-4 text-muted-foreground" />}
+            type="text"
+            value={general?.time || ''}
+            onChange={(e) => setFormField('general', 'time', e.target.value)}
+            onBlur={(e) => setFormField('general', 'time', e.target.value)}
+          />
+          <InputField
+            label="Call Sign"
+            id="call-sign"
+            placeholder="CALL SIGN"
+            icon={<Radio className="h-4 w-4 text-muted-foreground" />}
+            value={general?.callSign || ''}
+            onChange={(e) => setFormField('general', 'callSign', e.target.value)}
+            onBlur={(e) => setFormField('general', 'callSign', e.target.value)}
+          />
+        </div>
+      </FormSection>
+    );
+  }

--- a/src/components/arrest-report/officer-section.tsx
+++ b/src/components/arrest-report/officer-section.tsx
@@ -68,7 +68,6 @@ const InputField = ({
   value,
   onChange,
   required = true,
-  isInvalid = false,
 }: {
   label: string;
   id: string;
@@ -77,7 +76,6 @@ const InputField = ({
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   required?: boolean;
-  isInvalid?: boolean;
 }) => (
   <div className="grid gap-2">
     <Label htmlFor={id}>{label}</Label>
@@ -86,10 +84,7 @@ const InputField = ({
       <Input
         id={id}
         placeholder={placeholder}
-        className={cn(
-            'pl-9',
-            isInvalid && 'border-red-500 focus-visible:ring-red-500'
-        )}
+        className={cn('pl-9')}
         value={value}
         onChange={onChange}
         required={required}
@@ -107,7 +102,6 @@ const SelectField = ({
   onValueChange,
   children,
   required = true,
-  isInvalid = false,
 }: {
   label: string;
   id: string;
@@ -117,14 +111,13 @@ const SelectField = ({
   onValueChange: (value: string) => void;
   children: React.ReactNode;
   required?: boolean;
-  isInvalid?: boolean;
 }) => (
   <div className="grid gap-2">
     <Label htmlFor={id}>{label}</Label>
     <div className="relative flex items-center">
       <div className="absolute left-2.5 z-10">{icon}</div>
       <Select value={value} onValueChange={onValueChange} required={required}>
-        <SelectTrigger id={id} className={cn('pl-9', isInvalid && 'border-red-500 focus-visible:ring-red-500')}>
+        <SelectTrigger id={id} className={cn('pl-9', !value && required && 'border-red-500 focus-visible:ring-red-500')}>
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent>{children}</SelectContent>
@@ -134,7 +127,7 @@ const SelectField = ({
 );
 
 
-export function OfficerSection({ isSubmitted, isArrestReport = false, isMultiOfficer = true }: { isSubmitted: boolean, isArrestReport?: boolean, isMultiOfficer?: boolean }) {
+export function OfficerSection({ isArrestReport = false, isMultiOfficer = true }: { isArrestReport?: boolean, isMultiOfficer?: boolean }) {
   const { 
     officers, 
     updateOfficer, 
@@ -171,48 +164,45 @@ export function OfficerSection({ isSubmitted, isArrestReport = false, isMultiOff
         {officers.map((officer, index) => (
           <div key={officer.id} className="p-4 border rounded-lg space-y-4">
             <div className="grid grid-cols-1 gap-6 md:grid-cols-12 items-end">
-              <div className="md:col-span-4">
-                  <InputField
-                      label="Full Name"
-                      id={`officer-name-${officer.id}`}
-                      placeholder="John Doe"
-                      icon={<User className="h-4 w-4 text-muted-foreground" />}
-                      value={officer.name}
-                      onChange={(e) => updateOfficer(officer.id, { name: e.target.value })}
-                      isInvalid={isSubmitted && !officer.name}
-                  />
-              </div>
-              <div className="md:col-span-4">
-                  <SelectField
-                      label="Rank"
-                      id={`rank-${officer.id}`}
-                      placeholder="Select Rank"
-                      icon={<Shield className="h-4 w-4 text-muted-foreground" />}
-                      value={officer.department && officer.rank ? `${officer.department}__${officer.rank}` : ''}
-                      onValueChange={(value) => handleRankChange(officer.id, value)}
-                      isInvalid={isSubmitted && (!officer.rank || !officer.department)}
-                  >
-                      {Object.entries(deptRanks).map(([dept, ranks]) => (
-                          <SelectGroup key={dept}>
-                              <SelectLabel>{dept}</SelectLabel>
-                              {ranks.map((rank) => (
-                                  <SelectItem key={`${dept}-${rank}`} value={`${dept}__${rank}`}>{rank}</SelectItem>
-                              ))}
-                          </SelectGroup>
-                      ))}
-                  </SelectField>
-              </div>
-              <div className="md:col-span-3">
-                  <InputField
-                      label="Badge"
-                      id={`badge-${officer.id}`}
-                      placeholder="12345"
-                      icon={<BadgeIcon className="h-4 w-4 text-muted-foreground" />}
-                      value={officer.badgeNumber}
-                      onChange={(e) => updateOfficer(officer.id, { badgeNumber: e.target.value })}
-                      isInvalid={isSubmitted && !officer.badgeNumber}
-                  />
-              </div>
+                <div className="md:col-span-4">
+                    <InputField
+                        label="Full Name"
+                        id={`officer-name-${officer.id}`}
+                        placeholder="John Doe"
+                        icon={<User className="h-4 w-4 text-muted-foreground" />}
+                        value={officer.name}
+                        onChange={(e) => updateOfficer(officer.id, { name: e.target.value })}
+                    />
+                </div>
+                <div className="md:col-span-4">
+                    <SelectField
+                        label="Rank"
+                        id={`rank-${officer.id}`}
+                        placeholder="Select Rank"
+                        icon={<Shield className="h-4 w-4 text-muted-foreground" />}
+                        value={officer.department && officer.rank ? `${officer.department}__${officer.rank}` : ''}
+                        onValueChange={(value) => handleRankChange(officer.id, value)}
+                    >
+                        {Object.entries(deptRanks).map(([dept, ranks]) => (
+                            <SelectGroup key={dept}>
+                                <SelectLabel>{dept}</SelectLabel>
+                                {ranks.map((rank) => (
+                                    <SelectItem key={`${dept}-${rank}`} value={`${dept}__${rank}`}>{rank}</SelectItem>
+                                ))}
+                            </SelectGroup>
+                        ))}
+                    </SelectField>
+                </div>
+                <div className="md:col-span-3">
+                    <InputField
+                        label="Badge"
+                        id={`badge-${officer.id}`}
+                        placeholder="12345"
+                        icon={<BadgeIcon className="h-4 w-4 text-muted-foreground" />}
+                        value={officer.badgeNumber}
+                        onChange={(e) => updateOfficer(officer.id, { badgeNumber: e.target.value })}
+                    />
+                </div>
               <div className="md:col-span-1">
                   {index > 0 && (
                       <Button variant="ghost" size="icon" onClick={() => removeOfficer(officer.id)} type="button">

--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -27,6 +27,7 @@ import { useToast } from '@/hooks/use-toast';
 import { MultiSelect } from '../ui/multi-select';
 import { TextareaWithPreset } from '../shared/textarea-with-preset';
 import Handlebars from 'handlebars';
+import { cn } from '@/lib/utils';
 
 type FormField = {
     type: 'text' | 'textarea' | 'dropdown' | 'officer' | 'general' | 'section' | 'hidden' | 'toggle' | 'datalist' | 'charge' | 'group' | 'location' | 'input_group' | 'multi-select' | 'textarea-with-preset';
@@ -206,18 +207,17 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                 );
 
             case 'general':
-                return <GeneralSection key={fieldKey} isSubmitted={false} />;
+                return <GeneralSection key={fieldKey} />;
             
             case 'officer':
-                return <OfficerSection key={fieldKey} isSubmitted={false} isArrestReport={false} isMultiOfficer={field.multi} />;
+                return <OfficerSection key={fieldKey} isArrestReport={false} isMultiOfficer={field.multi} />;
 
             case 'location':
-                return <LocationDetails 
+                return <LocationDetails
                             key={fieldKey}
                             districtFieldName={`${field.name}.district`}
                             streetFieldName={`${field.name}.street`}
                             showDistrict={field.showDistrict !== false}
-                            isSubmitted={false}
                         />;
             case 'text':
                 return (
@@ -260,6 +260,7 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                                         placeholder={field.placeholder}
                                         searchPlaceholder='Search...'
                                         emptyPlaceholder='No results.'
+                                        isInvalid={field.required && !value}
                                     />
                                 )
                             }}
@@ -327,7 +328,7 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                         basePath={path}
                         control={control}
                         modifiers={field.modifiers || []}
-                        isInvalid={false}
+                        isInvalid={!!(field.required && !watch(`${path}.narrative`))}
                         noLocalStorage={field.noLocalStorage}
                         value={narrativeText}
                     />
@@ -344,7 +345,7 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                             defaultValue={field.defaultValue}
                             render={({ field: { onChange, value } }) => (
                                 <Select onValueChange={onChange} value={value} defaultValue={field.defaultValue}>
-                                    <SelectTrigger id={path}>
+                                    <SelectTrigger id={path} className={cn(field.required && !value && 'border-red-500 focus-visible:ring-red-500')}>
                                         <SelectValue placeholder={field.placeholder} />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -362,9 +363,10 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                  return (
                      <div key={fieldKey} className="w-full">
                          <Label htmlFor={path}>{field.label}</Label>
-                         <Controller
+                             <Controller
                              name={path}
                              control={control}
+                             rules={{ required: field.required }}
                              defaultValue={field.defaultValue || []}
                              render={({ field: { onChange, value } }) => (
                                  <MultiSelect
@@ -372,6 +374,7 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                                      onValueChange={onChange}
                                      defaultValue={value}
                                      placeholder={field.placeholder}
+                                     className={cn(field.required && (!value || value.length === 0) && 'border-red-500 focus-visible:ring-red-500')}
                                  />
                              )}
                             />

--- a/src/components/shared/location-details.tsx
+++ b/src/components/shared/location-details.tsx
@@ -11,16 +11,14 @@ interface LocationDetailsProps {
     districtFieldName: string;
     streetFieldName: string;
     showDistrict?: boolean;
-    isSubmitted?: boolean;
 }
 
-export function LocationDetails({ 
-    districtFieldName, 
-    streetFieldName, 
-    showDistrict = true, 
-    isSubmitted = false 
+export function LocationDetails({
+    districtFieldName,
+    streetFieldName,
+    showDistrict = true,
 }: LocationDetailsProps) {
-    const { control, getValues } = useFormContext();
+    const { control, watch } = useFormContext();
     const [locations, setLocations] = useState<{ districts: string[], streets: string[] }>({ districts: [], streets: [] });
     const { setFormField } = useFormStore();
 
@@ -36,8 +34,10 @@ export function LocationDetails({
             .catch(err => console.error("Failed to fetch locations:", err));
     }, []);
 
-    const isDistrictInvalid = isSubmitted && !getValues(districtFieldName);
-    const isStreetInvalid = isSubmitted && !getValues(streetFieldName);
+    const districtValue = watch(districtFieldName);
+    const streetValue = watch(streetFieldName);
+    const isDistrictInvalid = !districtValue;
+    const isStreetInvalid = !streetValue;
 
     return (
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,6 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         type={type}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "invalid:border-red-500 invalid:focus-visible:ring-red-500",
           className
         )}
         ref={ref}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,6 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'tex
       <textarea
         className={cn(
           'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'invalid:border-red-500 invalid:focus-visible:ring-red-500',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- show red borders on empty required inputs and textareas
- mark officer, location and paperwork generator controls invalid until populated
- simplify basic arrest report components by removing submit-driven validation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompt for ESLint configuration)*
- `npm run typecheck` *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f2c3e424832ab5f7f4b17744bb37