### PR TITLE
fix: keep custom narrative input

### DIFF
--- a/src/components/arrest-report/arrest-report-form.tsx
+++ b/src/components/arrest-report/arrest-report-form.tsx
@@ -327,6 +327,7 @@ export const ArrestReportForm = forwardRef((props, ref) => {
                         onTextChange={(newValue) => {
                             setFormField('arrest', 'narrative', newValue)
                         }}
+                        onUserModifiedChange={(value) => setUserModified('narrative', value)}
                         />
                 )}
             />

--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -27,6 +27,7 @@ interface TextareaWithPresetProps {
     noLocalStorage?: boolean;
     presetValue: string;
     onTextChange: (newValue: string) => void;
+    onUserModifiedChange?: (newValue: boolean) => void;
 }
 
 export function TextareaWithPreset({
@@ -40,6 +41,7 @@ export function TextareaWithPreset({
     noLocalStorage = false,
     presetValue,
     onTextChange,
+    onUserModifiedChange,
 }: TextareaWithPresetProps) {
     const { watch, setValue, getValues } = useFormContext();
     const [localValue, setLocalValue] = useState('');
@@ -80,8 +82,10 @@ export function TextareaWithPreset({
 
         if (newValue && !isUserModified) {
             setValue(`${basePath}.userModified`, true);
+            onUserModifiedChange?.(true);
         } else if (!newValue && isUserModified) {
             setValue(`${basePath}.userModified`, false);
+            onUserModifiedChange?.(false);
         }
     };
 


### PR DESCRIPTION
## Summary
- preserve manual edits in basic arrest report narrative
- track user-modified state to prevent preset overwrite

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: TS2345 ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a999ee1a08832a94b4f2caccbcd6c1