### PR TITLE
Preserve narrative modified state on basic arrest report

### DIFF
--- a/src/components/arrest-report/arrest-report-form.tsx
+++ b/src/components/arrest-report/arrest-report-form.tsx
@@ -328,6 +328,8 @@ export const ArrestReportForm = forwardRef((props, ref) => {
                             setFormField('arrest', 'narrative', newValue)
                         }}
                         onUserModifiedChange={(value) => setUserModified('narrative', value)}
+                        onModifierChange={(name, value) => setModifier(name, value)}
+                        onPresetChange={(value) => setPreset('narrative', value)}
                         />
                 )}
             />

--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -330,7 +330,7 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                         modifiers={field.modifiers || []}
                         isInvalid={!!(field.required && !watch(`${path}.narrative`))}
                         noLocalStorage={field.noLocalStorage}
-                        value={narrativeText}
+                        presetValue={narrativeText}
                     />
                 );
 


### PR DESCRIPTION
## Summary
- Track narrative text and modified status via callbacks so form resets don't revert user edits
- Align paperwork generator with updated TextareaWithPreset props
- Guard preset textarea effect so narrative updates only when preset text actually changes
- Persist modifier checkbox selections by syncing them with store
- Allow preset checkbox to update store and clear narrative when disabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive ESLint configuration)*
- `npm run typecheck` *(fails: cannot find module 'next-themes/dist/types', plus other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a8505ffc832a84dac771c83ec83d