### PR TITLE
Sanitize caselaw AI results

### DIFF
--- a/src/ai/flows/caselaw-assistant.ts
+++ b/src/ai/flows/caselaw-assistant.ts
@@ -5,6 +5,7 @@ import { ai } from '@/ai/genkit';
 import { z } from 'genkit';
 import caselaws from '@/../data/caselaws.json';
 import { Action, Tool } from 'genkit/experimental/ai';
+import { sanitizeLocations } from '@/lib/sanitize-locations';
 
 const CaselawInputSchema = z.object({
     query: z.string().describe('The user\'s question about a caselaw.'),
@@ -71,12 +72,7 @@ const oyezSearchTool = ai.defineTool({
         { name: "Brandenburg v. Ohio", href: "https://www.oyez.org/cases/1968/492" }
     ];
 
-    const processedResults = MOCKED_OYEZ_RESULTS.map(caseInfo => ({
-        ...caseInfo,
-        name: caseInfo.name
-            .replace(/California/g, 'San Andreas')
-            .replace(/Los Angeles/g, 'Los Santos')
-    }));
+    const processedResults = sanitizeLocations(MOCKED_OYEZ_RESULTS);
 
     return { oyez_cases: processedResults };
 });
@@ -118,6 +114,7 @@ export const caselawAssistantFlow = ai.defineFlow(
         if (!output) {
             throw new Error("The AI failed to produce a valid output.");
         }
-        return output;
+        const sanitized = sanitizeLocations(output) as CaselawOutput;
+        return sanitized;
     }
 );

--- a/src/components/caselaw/caselaw-ai-dialog.tsx
+++ b/src/components/caselaw/caselaw-ai-dialog.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from '../ui/skeleton';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Separator } from '../ui/separator';
+import { sanitizeLocations } from '@/lib/sanitize-locations';
 
 const jurisdictionMap: { [key: string]: string } = {
     'federal': 'Federal',
@@ -50,7 +51,7 @@ export function CaselawAIDialog({ open, onOpenChange }: CaselawAIDialogProps) {
 
     try {
       const flowResult = await caselawAssistantFlow({ query });
-      setResult(flowResult);
+      setResult(sanitizeLocations(flowResult));
     } catch (err) {
       console.error(err);
       setError('An error occurred while fetching the answer. Please try again.');

--- a/src/lib/sanitize-locations.ts
+++ b/src/lib/sanitize-locations.ts
@@ -1,0 +1,21 @@
+export function sanitizeLocations<T>(data: T): T {
+  const replace = (str: string) =>
+    str.replace(/California/g, 'San Andreas').replace(/Los Angeles/g, 'Los Santos');
+
+  const traverse = (val: any): any => {
+    if (typeof val === 'string') {
+      return replace(val);
+    }
+    if (Array.isArray(val)) {
+      return val.map(traverse);
+    }
+    if (val && typeof val === 'object') {
+      return Object.fromEntries(
+        Object.entries(val).map(([k, v]) => [k, traverse(v)])
+      );
+    }
+    return val;
+  };
+
+  return traverse(data);
+}


### PR DESCRIPTION
## Summary
- sanitize caselaw AI outputs by replacing "California" with "San Andreas" and "Los Angeles" with "Los Santos"
- apply location sanitization to mocked Oyez search results and overall caselaw assistant flow
- ensure caselaw AI dialog sanitizes results before display

## Testing
- `npm run typecheck` *(fails: Cannot find module 'genkit/experimental/ai' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac825e3ea4832a95509b926c627815