### PR TITLE
fix warrant affidavit narrative preset generation

### DIFF
--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -301,7 +301,8 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                         const dependenciesMet = (mod.requires || []).every((dep: string) => watch(`${path}.modifiers.${dep}`));
                         if (isEnabled && dependenciesMet) {
                             try {
-                                const template = Handlebars.compile(mod.text || '', { noEscape: true });
+                                const templateSource = (mod as any).generateText || mod.text || '';
+                                const template = Handlebars.compile(templateSource, { noEscape: true });
                                 dataForHandlebars.modifiers[mod.name] = template(dataForHandlebars);
                             } catch (e) {
                                 console.error(`Error compiling Handlebars template for modifier ${mod.name}:`, e);


### PR DESCRIPTION
## Summary
- ensure paperwork generator recognizes `generateText` modifier field when generating narrative presets

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad95c1e250832aadfa70cec2115d3d