### PR TITLE
Enable modifier stipulations in paperwork generator

### DIFF
--- a/data/paperwork-generators/warrant-affidavit.json
+++ b/data/paperwork-generators/warrant-affidavit.json
@@ -31,7 +31,7 @@
                 {
                     "name": "introduction",
                     "label": "Affiant Introduction",
-                    "generateText": "I, {{officers.0.rank}} {{officers.0.name}} (#{{officers.0.badgeNumber}}), am a peace officer employed with the {{officers.0.department}}, currently assigned to the {{officers.0.divDetail}}. I have been employed by this agency for [X] years and have extensive experience in [briefly describe experience, e.g., narcotics investigations, homicide, etc.]."
+                    "generateText": "I, {{officers.0.rank}} {{officers.0.name}} (#{{officers.0.badgeNumber}}), am a peace officer employed with the {{officers.0.department}}, currently assigned to the {{officers.0.divDetail}}. I have been employed by this agency for {{introduction_years}} years and have extensive experience in {{introduction_experience}}."
                 },
                 {
                     "name": "submission_statement",
@@ -54,6 +54,9 @@
                     "generateText": "Based on the information contained in this affidavit, I respectfully request that this court issue the requested {{warrant_type}}.\n\nI declare under penalty of perjury that the foregoing is true and correct.\n\n{{officers.0.name}}\n{{officers.0.rank}}\n{{officers.0.department}}\nDATED: {{general.date}}"
                 }
             ]
-        }
+        },
+        { "type": "section", "title": "Affiant Introduction Details", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.introduction", "value": true}] },
+        { "type": "text", "name": "introduction_years", "label": "Years of Experience", "placeholder": "e.g. 5", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.introduction", "value": true}] },
+        { "type": "text", "name": "introduction_experience", "label": "Extensive Experience", "placeholder": "e.g. narcotics investigations", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.introduction", "value": true}] }
     ]
 }

--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -48,6 +48,10 @@ type FormField = {
         field: string;
         value: any;
     },
+    stipulations?: {
+        field: string;
+        value: any;
+    }[],
     fields?: FormField[]; // For group and input_group types
     // Charge field specific config
     showClass?: boolean;
@@ -188,8 +192,15 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
         index?: number,
     ) => {
         const fieldKey = `${path}-${index}`;
-
-        if (field.stipulation) {
+        if (field.stipulations) {
+            const allMet = field.stipulations.every(stip => {
+                const watchedValue = watch(stip.field);
+                return String(watchedValue) === String(stip.value);
+            });
+            if (!allMet) {
+                return null;
+            }
+        } else if (field.stipulation) {
             const watchedValue = watch(field.stipulation.field);
             if (String(watchedValue) !== String(field.stipulation.value)) {
                 return null;

--- a/src/stores/paperwork-builder-store.ts
+++ b/src/stores/paperwork-builder-store.ts
@@ -19,6 +19,10 @@ export type Field = {
       field: string;
       value: any;
     },
+    stipulations?: {
+      field: string;
+      value: any;
+    }[],
     fields?: Field[]; // For group type
     // Charge field specific config
     showClass?: boolean;


### PR DESCRIPTION
## Summary
- allow fields to require multiple stipulations
- show affiant introduction details when corresponding modifier is active

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ad99227220832aba15ff27946cf843