### PR TITLE
Streamline warrant affidavit form fields

### DIFF
--- a/data/paperwork-generators/warrant-affidavit.json
+++ b/data/paperwork-generators/warrant-affidavit.json
@@ -25,8 +25,7 @@
 
         { "type": "section", "title": "Submission Statement Details", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.submission_statement", "value": true}] },
         { "type": "text", "name": "submission_subject", "label": "Subject/Location", "placeholder": "e.g., John Doe or 1234 Imagination Ave", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.submission_statement", "value": true}] },
-        { "type": "text", "name": "submission_crimes", "label": "Crime(s)", "placeholder": "e.g., PC 11351, PC 11378", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.submission_statement", "value": true}] },
-        { "type": "text", "name": "submission_casefile", "label": "Casefile Number", "placeholder": "e.g., DR#12345-24", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.submission_statement", "value": true}] },
+        { "type": "charge", "name": "charges", "label": "Crime(s)", "showClass": true, "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.submission_statement", "value": true}] },
         
         { "type": "section", "title": "Probable Cause Details", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.probable_cause", "value": true}] },
         { "type": "text", "name": "pc_date", "label": "Date of Initial Event", "placeholder": "e.g., 01/JAN/2024", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.probable_cause", "value": true}] },
@@ -37,7 +36,9 @@
         { "type": "textarea", "name": "pc_conclusion", "label": "Evidence Conclusion", "placeholder": "Explain what the evidence shows and how it links the subject/location to the crime.", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.probable_cause", "value": true}] },
 
         { "type": "section", "title": "Scope of Request Details", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.scope_of_request", "value": true}] },
-        { "type": "textarea", "name": "scope_items", "label": "Items to be Searched/Seized/Monitored", "placeholder": "List specific items, one per line. e.g.,\n- One (1) black Glock 19 handgun\n- Any and all illicit narcotics...", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.scope_of_request", "value": true}] },
+        { "type": "input_group", "name": "scope_items", "label": "Items to be Searched/Seized/Monitored", "fields": [
+            { "type": "text", "name": "item", "label": "Item", "placeholder": "e.g., One (1) black Glock 19 handgun" }
+        ], "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.scope_of_request", "value": true}] },
 
         { "type": "section", "title": "Affidavit" },
         {
@@ -56,7 +57,7 @@
                 {
                     "name": "submission_statement",
                     "label": "Submission Statement",
-                    "generateText": "I submit this affidavit in support of an {{warrant_type}} for {{submission_subject}}. This request is based on an ongoing investigation into {{submission_crimes}} (Casefile #{{submission_casefile}})."
+                    "generateText": "I submit this affidavit in support of an {{warrant_type}} for {{submission_subject}}. This request is based on an ongoing investigation into {{#each charges}}{{#with (lookup @root.penalCode chargeId)}}{{charge}}{{/with}}{{#unless @last}}, {{/unless}}{{/each}}."
                 },
                 {
                     "name": "probable_cause",
@@ -66,7 +67,7 @@
                 {
                     "name": "scope_of_request",
                     "label": "Scope of Request",
-                    "generateText": "Based on the probable cause outlined above, I request authorization to search, seize, and/or monitor the following:\n{{scope_items}}"
+                    "generateText": "Based on the probable cause outlined above, I request authorization to search, seize, and/or monitor the following:\n{{#each scope_items}}- {{item}}\n{{/each}}"
                 },
                 {
                     "name": "conclusion",

--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -99,6 +99,8 @@ const buildDefaultValues = (fields: FormField[]): Record<string, any> => {
             Object.assign(defaults, buildDefaultValues(field.fields));
         } else if (field.type === 'input_group' && field.name) {
             defaults[field.name] = field.defaultValue ?? [];
+        } else if (field.type === 'charge' && field.name) {
+            defaults[field.name] = field.defaultValue ?? [];
         } else if (field.type === 'textarea-with-preset' && field.name) {
              defaults[field.name] = {
                 modifiers: (field.modifiers || []).reduce((acc, mod) => ({...acc, [mod.name]: true }), {}),
@@ -123,9 +125,14 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
     const router = useRouter();
     const searchParams = useSearchParams();
 
+    const defaultValues = useMemo(
+        () => buildDefaultValues(generatorConfig.form),
+        [generatorConfig.form]
+    );
+
     const methods = useForm({
         criteriaMode: 'all',
-        defaultValues: buildDefaultValues(generatorConfig.form)
+        defaultValues
     });
     const { register, handleSubmit, control, watch, trigger, getValues } = methods;
 


### PR DESCRIPTION
## Summary
- Replace crime input with charge picker limited to class selection and drop casefile number usage
- Convert item scope field into an expandable list for adding/removing entries
- Memoize default generator values to prevent infinite form rerenders

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ada659ef14832a97704fb42f9b2846