### PR TITLE
fix: prevent textarea preset update loop

### DIFF
--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -50,21 +50,24 @@ export function TextareaWithPreset({
     const { watch, setValue, getValues, trigger } = useFormContext();
     const [localValue, setLocalValue] = useState(getValues(`${basePath}.narrative`) || '');
     const isInitialMount = useRef(true);
+    const previousPreset = useRef(presetValue);
 
     const isPresetEnabled = watch(`${basePath}.isPreset`);
     const isUserModified = watch(`${basePath}.userModified`);
-    
+
     useEffect(() => {
         if (isInitialMount.current) {
             isInitialMount.current = false;
+            previousPreset.current = presetValue;
             return;
         }
-        if (isPresetEnabled && !isUserModified && localValue !== presetValue) {
+        if (isPresetEnabled && !isUserModified && presetValue !== previousPreset.current) {
             setLocalValue(presetValue);
             setValue(`${basePath}.narrative`, presetValue, { shouldDirty: true });
             onTextChange?.(presetValue);
+            previousPreset.current = presetValue;
         }
-    }, [presetValue, isPresetEnabled, isUserModified, setValue, onTextChange, localValue]);
+    }, [presetValue, isPresetEnabled, isUserModified, setValue, onTextChange]);
 
 
     const handleTogglePreset = (checked: boolean) => {


### PR DESCRIPTION
## Summary
- avoid repeated preset synchronization in `TextareaWithPreset` by tracking previous preset value

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb0dcbef8832ab9e5973e02ce134f