### PR TITLE
fix: prevent textarea preset update loop

### DIFF
--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -49,22 +49,21 @@ export function TextareaWithPreset({
 }: TextareaWithPresetProps) {
     const { watch, setValue, getValues, trigger } = useFormContext();
     const [localValue, setLocalValue] = useState(getValues(`${basePath}.narrative`) || '');
-    const isInitialMount = useRef(true);
-
     const isPresetEnabled = watch(`${basePath}.isPreset`);
     const isUserModified = watch(`${basePath}.userModified`);
-    
+    const onTextChangeRef = useRef(onTextChange);
+
     useEffect(() => {
-        if (isInitialMount.current) {
-            isInitialMount.current = false;
-            return;
-        }
-        if (isPresetEnabled && !isUserModified && localValue !== presetValue) {
+        onTextChangeRef.current = onTextChange;
+    }, [onTextChange]);
+
+    useEffect(() => {
+        if (isPresetEnabled && !isUserModified && presetValue !== localValue) {
             setLocalValue(presetValue);
             setValue(`${basePath}.narrative`, presetValue, { shouldDirty: true });
-            onTextChange?.(presetValue);
+            onTextChangeRef.current?.(presetValue);
         }
-    }, [presetValue, isPresetEnabled, isUserModified, setValue, onTextChange, localValue]);
+    }, [presetValue, isPresetEnabled, isUserModified, localValue, setValue]);
 
 
     const handleTogglePreset = (checked: boolean) => {


### PR DESCRIPTION
## Summary
- only sync preset narrative when it differs from local value to stop re-render loops
- keep preset text change callback in a ref to avoid extra effect triggers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb0dcbef8832ab9e5973e02ce134f