### PR TITLE
Support multi-item textarea presets

### DIFF
--- a/data/paperwork-generators/warrant-affidavit.json
+++ b/data/paperwork-generators/warrant-affidavit.json
@@ -37,7 +37,9 @@
         { "type": "textarea", "name": "pc_conclusion", "label": "Evidence Conclusion", "placeholder": "Explain what the evidence shows and how it links the subject/location to the crime.", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.probable_cause", "value": true}] },
 
         { "type": "section", "title": "Scope of Request Details", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.scope_of_request", "value": true}] },
-        { "type": "textarea", "name": "scope_items", "label": "Items to be Searched/Seized/Monitored", "placeholder": "List specific items, one per line. e.g.,\n- One (1) black Glock 19 handgun\n- Any and all illicit narcotics...", "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.scope_of_request", "value": true}] },
+        { "type": "input_group", "name": "scope_items", "label": "Items to be Searched/Seized/Monitored", "fields": [
+            { "type": "text", "name": "item", "label": "Item", "placeholder": "e.g., One (1) black Glock 19 handgun" }
+        ], "stipulations": [{"field": "narrative.isPreset", "value": true}, {"field": "narrative.modifiers.scope_of_request", "value": true}] },
 
         { "type": "section", "title": "Affidavit" },
         {
@@ -66,7 +68,7 @@
                 {
                     "name": "scope_of_request",
                     "label": "Scope of Request",
-                    "generateText": "Based on the probable cause outlined above, I request authorization to search, seize, and/or monitor the following:\n{{scope_items}}"
+                    "generateText": "Based on the probable cause outlined above, I request authorization to search, seize, and/or monitor the following:\n{{#each scope_items}}- {{item}}\n{{/each}}"
                 },
                 {
                     "name": "conclusion",

--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useForm, Controller, FormProvider, useFieldArray, FieldErrors } from 'react-hook-form';
+import { useForm, Controller, FormProvider, useFieldArray, FieldErrors, useWatch } from 'react-hook-form';
 import { PageHeader } from '../dashboard/page-header';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
@@ -128,6 +128,7 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
         defaultValues: buildDefaultValues(generatorConfig.form)
     });
     const { register, handleSubmit, control, watch, trigger, getValues } = methods;
+    const watchedForm = useWatch({ control });
 
     const officers = useOfficerStore(state => state.officers);
     const generalData = useBasicFormStore(state => state.formData.general);
@@ -297,7 +298,7 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                         return watch(`${path}.narrative`);
                     }
 
-                    const allData = watch();
+                    const allData = watchedForm;
                     const externalData: any = {};
 
                     (field.refreshOn || []).forEach(dep => {

--- a/src/components/shared/officer-section.tsx
+++ b/src/components/shared/officer-section.tsx
@@ -130,26 +130,25 @@ const SelectField = ({
 
 
 export function OfficerSection({ isArrestReport = false, isMultiOfficer = true }: { isArrestReport?: boolean, isMultiOfficer?: boolean }) {
-  const { 
-    officers, 
-    updateOfficer, 
-    removeOfficer, 
-    setInitialOfficers, 
-    addOfficer,
-    alternativeCharacters,
-    swapOfficer,
-  } = useOfficerStore();
+  const officers = useOfficerStore(state => state.officers);
+  const updateOfficer = useOfficerStore(state => state.updateOfficer);
+  const removeOfficer = useOfficerStore(state => state.removeOfficer);
+  const setInitialOfficers = useOfficerStore(state => state.setInitialOfficers);
+  const addOfficer = useOfficerStore(state => state.addOfficer);
+  const alternativeCharacters = useOfficerStore(state => state.alternativeCharacters);
+  const swapOfficer = useOfficerStore(state => state.swapOfficer);
   const [deptRanks, setDeptRanks] = useState<DeptRanks>({});
   const { toggleAdvanced } = useAdvancedReportStore();
 
   const showLspdWarning = isArrestReport && officers.some(o => o.department === 'Los Santos Police Department');
 
   useEffect(() => {
-    setInitialOfficers(); 
+    setInitialOfficers();
     fetch('/data/dept_ranks.json')
       .then((res) => res.json())
       .then((data) => setDeptRanks(data));
-  }, [setInitialOfficers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   
   const handlePillClick = (officerId: number, altChar: Officer) => {
     swapOfficer(officerId, altChar);


### PR DESCRIPTION
## Summary
- watch full form values to update textarea presets when multi fields change
- allow warrant affidavit generator to list multiple scope items using an input group
- initialize officer store once to avoid infinite re-rendering

## Testing
- no tests run


------
https://chatgpt.com/codex/tasks/task_e_68adc6a6a0cc832a990b57767bfc6937