### PR TITLE
Support textarea presets inside multi-input groups

### DIFF
--- a/data/paperwork-generators/test-multi-input-preset.json
+++ b/data/paperwork-generators/test-multi-input-preset.json
@@ -1,0 +1,31 @@
+{
+    "id": "test-multi-input-preset",
+    "title": "Test Multi Input Preset",
+    "description": "Generator for testing textarea presets inside multi-input groups.",
+    "icon": "FileText",
+    "output": "{{#each entries}}Title: {{title}}\nDetails: {{details.narrative}}\n---\n{{/each}}",
+    "form": [
+        {
+            "type": "input_group",
+            "name": "entries",
+            "label": "Entries",
+            "fields": [
+                {
+                    "type": "text",
+                    "name": "title",
+                    "label": "Title",
+                    "placeholder": "Entry title"
+                },
+                {
+                    "type": "textarea-with-preset",
+                    "name": "details",
+                    "label": "Details",
+                    "preset": "{{modifiers.base}}",
+                    "modifiers": [
+                        { "name": "base", "label": "Base", "text": "Default preset text." }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -485,8 +485,8 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                     {fields.map((item, index) => (
                         <div key={item.id} className="flex items-start gap-2 p-4 border rounded-lg">
                             <div className="flex-1 space-y-4">
-                                {fieldConfig.fields?.map((subField) => (
-                                    renderField(subField, `${fieldConfig.name}.${index}.${subField.name}`)
+                                {fieldConfig.fields?.map((subField, subIndex) => (
+                                    renderField(subField, `${fieldConfig.name}.${index}.${subField.name}`, subIndex)
                                 ))}
                             </div>
                             <Button type="button" variant="ghost" size="icon" onClick={() => remove(index)}>
@@ -494,7 +494,11 @@ function PaperworkGeneratorFormComponent({ generatorConfig }: PaperworkGenerator
                             </Button>
                         </div>
                     ))}
-                    <Button type="button" variant="outline" onClick={() => append(fieldConfig.fields?.reduce((acc, f) => ({...acc, [f.name]: f.defaultValue || ''}), {}) || {})}>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => append(buildDefaultValues(fieldConfig.fields || []))}
+                    >
                         <Plus className="mr-2 h-4 w-4" /> Add {fieldConfig.label}
                     </Button>
                 </CardContent>


### PR DESCRIPTION
## Summary
- initialize default values when adding fields to multi-input groups to allow textarea-with-preset fields
- add example paperwork generator using textarea-with-preset inside a multi-input group

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aed6e67f04832a97e50006958c5dde