### PR TITLE
feat: support multi-input modifiers for textarea presets

### DIFF
--- a/data/paperwork-generators/test-textarea-preset.json
+++ b/data/paperwork-generators/test-textarea-preset.json
@@ -1,0 +1,37 @@
+{
+    "id": "test-textarea-preset",
+    "title": "Test Textarea Preset",
+    "description": "Generator used for testing textarea with preset and multi-input support.",
+    "icon": "FileText",
+    "generator_disabled": false,
+    "is_html_output": false,
+    "output": "{{narrative.narrative}}",
+    "form": [
+        { "type": "section", "title": "Test Fields" },
+        {
+            "type": "textarea-with-preset",
+            "name": "narrative",
+            "label": "Test Narrative",
+            "noLocalStorage": true,
+            "preset": "{{modifiers.items}}",
+            "modifiers": [
+                {
+                    "name": "items",
+                    "label": "Include Items",
+                    "generateText": "{{#each items}}- {{this.name}}: {{this.detail}}\n{{/each}}",
+                    "fields": [
+                        {
+                            "type": "input_group",
+                            "name": "items",
+                            "label": "Items",
+                            "fields": [
+                                { "type": "text", "name": "name", "label": "Name" },
+                                { "type": "text", "name": "detail", "label": "Detail" }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- allow `textarea-with-preset` modifiers to render additional input fields, including multi-input groups
- prevent usage of `textarea-with-preset` inside an `input_group`
- add test paperwork generator demonstrating multi-input modifier support

## Testing
- `npm run typecheck` *(fails: Property 'type' is missing in type 'Record<"id", string>' but required in type 'Field'.)*

------
https://chatgpt.com/codex/tasks/task_e_68aed9a6ff98832a91cd70533badc974