### PR TITLE
Support input groups inside textarea presets

### DIFF
--- a/data/paperwork-generators/test-multi-input.json
+++ b/data/paperwork-generators/test-multi-input.json
@@ -1,0 +1,39 @@
+{
+  "id": "test-multi-input",
+  "title": "Multi Input Textarea Test",
+  "description": "Test generator for textarea-with-preset with input group modifiers.",
+  "icon": "ClipboardList",
+  "generator_disabled": false,
+  "is_html_output": false,
+  "output": "{{narrative.narrative}}",
+  "form": [
+    {
+      "type": "input_group",
+      "name": "extras",
+      "label": "External Items",
+      "fields": [
+        { "type": "text", "name": "item", "label": "Item", "placeholder": "Item detail" }
+      ]
+    },
+    {
+      "type": "textarea-with-preset",
+      "name": "narrative",
+      "label": "Narrative",
+      "preset": "{{modifiers.items}}\n{{#each extras}}- {{item}}\\n{{/each}}",
+      "modifiers": [
+        {
+          "name": "items",
+          "label": "List Items",
+          "generateText": "{{#each narrative.modifierInputs.items}}{{this.name}}: {{this.detail}}\\n{{/each}}",
+          "inputGroup": {
+            "label": "Item",
+            "fields": [
+              { "type": "text", "name": "name", "label": "Name", "placeholder": "Item name" },
+              { "type": "text", "name": "detail", "label": "Detail", "placeholder": "Item detail" }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -1,19 +1,27 @@
 
 'use client';
 import React, { useEffect, useState, useRef } from 'react';
-import { Control, Controller, useFormContext } from 'react-hook-form';
+import { Control, Controller, useFormContext, useFieldArray } from 'react-hook-form';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { Separator } from '../ui/separator';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Trash2, Plus } from 'lucide-react';
 
 export type Modifier = {
     name: string;
     label: string;
     text?: string;
     requires?: string[];
+    inputGroup?: {
+        label: string;
+        fields: any[];
+    };
 };
 
 interface TextareaWithPresetProps {
@@ -64,7 +72,7 @@ export function TextareaWithPreset({
             setValue(`${basePath}.narrative`, presetValue, { shouldDirty: true });
             onTextChange?.(presetValue);
         }
-    }, [presetValue, isPresetEnabled, isUserModified, setValue, onTextChange, localValue]);
+    }, [presetValue, isPresetEnabled, isUserModified, setValue, onTextChange]);
 
 
     const handleTogglePreset = (checked: boolean) => {
@@ -153,6 +161,19 @@ export function TextareaWithPreset({
                      </div>
                 ))}
             </div>
+            {modifiers.map(mod => {
+                const enabled = watch(`${basePath}.modifiers.${mod.name}`);
+                if (mod.inputGroup && enabled) {
+                    return (
+                        <ModifierInputGroup
+                            key={`${mod.name}-group`}
+                            basePath={`${basePath}.modifierInputs.${mod.name}`}
+                            groupConfig={mod.inputGroup}
+                        />
+                    );
+                }
+                return null;
+            })}
             <Textarea
                 value={localValue}
                 id={`${basePath}.narrative`}
@@ -165,3 +186,68 @@ export function TextareaWithPreset({
         </div>
     );
 }
+
+const ModifierInputGroup = ({ basePath, groupConfig }: { basePath: string; groupConfig: any }) => {
+    const { control, register } = useFormContext();
+
+    if (groupConfig.fields?.some((f: any) => f.type === 'textarea-with-preset')) {
+        return <p className="text-red-500">textarea-with-preset cannot be used inside an input group.</p>;
+    }
+
+    const { fields, append, remove } = useFieldArray({ control, name: basePath });
+
+    const renderField = (field: any, path: string) => {
+        switch (field.type) {
+            case 'text':
+                return (
+                    <div key={path} className="w-full">
+                        <Label htmlFor={path}>{field.label}</Label>
+                        <Input id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} />
+                    </div>
+                );
+            case 'textarea':
+                return (
+                    <div key={path} className="w-full">
+                        <Label htmlFor={path}>{field.label}</Label>
+                        <Textarea id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} />
+                    </div>
+                );
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <Card className="mb-4">
+            <CardHeader>
+                <CardTitle>{groupConfig.label}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {fields.map((item, index) => (
+                    <div key={item.id} className="flex items-start gap-2 p-4 border rounded-lg">
+                        <div className="flex-1 space-y-4">
+                            {groupConfig.fields?.map((sub: any) => renderField(sub, `${basePath}.${index}.${sub.name}`))}
+                        </div>
+                        <Button type="button" variant="ghost" size="icon" onClick={() => remove(index)}>
+                            <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                    </div>
+                ))}
+                <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() =>
+                        append(
+                            groupConfig.fields?.reduce(
+                                (acc: any, f: any) => ({ ...acc, [f.name]: f.defaultValue || '' }),
+                                {}
+                            ) || {}
+                        )
+                    }
+                >
+                    <Plus className="mr-2 h-4 w-4" /> Add {groupConfig.label}
+                </Button>
+            </CardContent>
+        </Card>
+    );
+};


### PR DESCRIPTION
## Summary
- allow textarea-with-preset modifiers to host input groups
- block textarea-with-preset usage within input_group fields
- add test paperwork generator using multi-input modifier
- subscribe textarea presets to external input groups
- avoid infinite preset update loops by simplifying sync logic

## Testing
- `npx tsc --noEmit` *(fails: Type 'null' is not assignable to type 'string | undefined'.
    src/components/paperwork-generators/paperwork-generator-builder.tsx(230,38): error TS2741: Property 'type' is missing in type 'Record<"id", string>' but required in type 'Field'.
    src/components/paperwork-generators/paperwork-generator-builder.tsx(421,116): error TS2345: Argument of type 'Partial<Field>' is not assignable to parameter of type 'Field | Field[]'.
    src/components/paperwork-generators/paperwork-generator-form.tsx(458,29): error TS2719: Type 'FormField[] | undefined' is not assignable to type 'FormField[] | undefined'. Two different types with this name exist, but they are unrelated.
    src/components/paperwork-submit/paperwork-submit-page.tsx(214,35): error TS2322: Type 'RefObject<HTMLDivElement | null>' is not assignable to type 'RefObject<HTMLDivElement>'.
    src/components/theme-provider.tsx(5,41): error TS2307: Cannot find module 'next-themes/dist/types' or its corresponding type declarations.
    src/components/ui/calendar.tsx(57,9): error TS2353: Object literal may only specify known properties, and 'IconLeft' does not exist in type 'Partial<CustomComponents>'.
    src/components/ui/calendar.tsx(57,22): error TS7031: Binding element 'className' implicitly has an 'any' type.
    src/components/ui/calendar.tsx(60,23): error TS7031: Binding element 'className' implicitly has an 'any' type.)`

------
https://chatgpt.com/codex/tasks/task_e_68aed9a6ff98832a91cd70533badc974