### PR TITLE
feat: improve paperwork generator validation

### DIFF
--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -194,7 +194,10 @@ export function TextareaWithPreset({
 }
 
 export const ModifierInputGroup = ({ basePath, groupConfig }: { basePath: string; groupConfig: any }) => {
-    const { control, register } = useFormContext();
+    const { control, register, formState: { errors } } = useFormContext();
+    const fieldHasError = (path: string): boolean => {
+        return path.split('.').reduce<any>((acc, part) => (acc ? acc[part] : undefined), errors) !== undefined;
+    };
     const { fields, append, remove } = useFieldArray({ control, name: basePath });
 
     if (groupConfig.fields?.some((f: any) => f.type === 'textarea-with-preset')) {
@@ -207,14 +210,14 @@ export const ModifierInputGroup = ({ basePath, groupConfig }: { basePath: string
                 return (
                     <div key={path} className="w-full">
                         <Label htmlFor={path}>{field.label}</Label>
-                        <Input id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} />
+                        <Input id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} className={cn(fieldHasError(path) && 'border-red-500 focus-visible:ring-red-500')} />
                     </div>
                 );
             case 'textarea':
                 return (
                     <div key={path} className="w-full">
                         <Label htmlFor={path}>{field.label}</Label>
-                        <Textarea id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} />
+                        <Textarea id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} className={cn(fieldHasError(path) && 'border-red-500 focus-visible:ring-red-500')} />
                     </div>
                 );
             default:


### PR DESCRIPTION
## Summary
- avoid stack overflow when collecting validation errors
- highlight required paperwork generator fields in red when empty

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aefba04f94832a9dc426bd6f0fa076