### PR TITLE
Improve paperwork generator validation

### DIFF
--- a/src/components/shared/textarea-with-preset.tsx
+++ b/src/components/shared/textarea-with-preset.tsx
@@ -194,7 +194,19 @@ export function TextareaWithPreset({
 }
 
 export const ModifierInputGroup = ({ basePath, groupConfig }: { basePath: string; groupConfig: any }) => {
-    const { control, register } = useFormContext();
+    const { control, register, formState: { errors } } = useFormContext();
+    const isInvalid = (fieldName: string) => {
+        const parts = fieldName.split('.');
+        let error: any = errors;
+        for (const part of parts) {
+            if (error && part in error) {
+                error = error[part];
+            } else {
+                return false;
+            }
+        }
+        return !!error;
+    };
     const { fields, append, remove } = useFieldArray({ control, name: basePath });
 
     if (groupConfig.fields?.some((f: any) => f.type === 'textarea-with-preset')) {
@@ -207,14 +219,14 @@ export const ModifierInputGroup = ({ basePath, groupConfig }: { basePath: string
                 return (
                     <div key={path} className="w-full">
                         <Label htmlFor={path}>{field.label}</Label>
-                        <Input id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} />
+                        <Input id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} className={cn(isInvalid(path) && 'border-red-500 focus-visible:ring-red-500')} />
                     </div>
                 );
             case 'textarea':
                 return (
                     <div key={path} className="w-full">
                         <Label htmlFor={path}>{field.label}</Label>
-                        <Textarea id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} />
+                        <Textarea id={path} {...register(path, { required: field.required })} placeholder={field.placeholder} className={cn(isInvalid(path) && 'border-red-500 focus-visible:ring-red-500')} />
                     </div>
                 );
             default:


### PR DESCRIPTION
## Summary
- Prevent recursive loops when collecting form errors in paperwork generators
- Highlight required generator fields in red like the arrest report
- Ensure modifier input groups validate and show errors consistently

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Type 'null' is not assignable...)*

------
https://chatgpt.com/codex/tasks/task_e_68aefba04f94832a9dc426bd6f0fa076