### PR TITLE
Load beta settings from shared config

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -10,6 +10,8 @@
     "SITE_DESCRIPTION": "MDC Panel+ - Multi-functional tools, generators, and resources for community use.",
     "SITE_DISCORD_CONTACT": "booskit",
     "ENABLE_FORM_BUILDER": false,
+    "BETA_ENABLED": true,
+    "BETA_CODE": "",
     "MAX_SENTENCE_DAYS": 25,
     "CONTENT_DELIVERY_NETWORK": "https://sys.booskit.dev/cdn/serve.php",
     "URL_GITHUB": "https://github.com/b00skit/MDC-Panel-plus",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,4 @@
 import type {NextConfig} from 'next';
-import config from './data/config.json';
 
 const nextConfig: NextConfig = {
   /* config options here */
@@ -10,8 +9,6 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   env: {
-    NEXT_PUBLIC_BETA_ENABLED: config.BETA_ENABLED,
-    NEXT_PUBLIC_BETA_CODE: config.BETA_CODE,
   }
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type {NextConfig} from 'next';
+import config from './data/config.json';
 
 const nextConfig: NextConfig = {
   /* config options here */
@@ -9,8 +10,8 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   env: {
-    NEXT_PUBLIC_BETA_ENABLED: process.env.BETA_ENABLED,
-    NEXT_PUBLIC_BETA_CODE: process.env.BETA_CODE,
+    NEXT_PUBLIC_BETA_ENABLED: config.BETA_ENABLED,
+    NEXT_PUBLIC_BETA_CODE: config.BETA_CODE,
   }
 };
 

--- a/src/components/layout/client-layout.tsx
+++ b/src/components/layout/client-layout.tsx
@@ -3,6 +3,7 @@
 
 import React, { useState, useEffect } from 'react';
 import FullScreenMessage from '@/components/layout/maintenance-page';
+import configData from '../../../data/config.json';
 
 async function clearCaches() {
   try {
@@ -94,7 +95,7 @@ const BetaRedirect = ({ children }: { children: React.ReactNode }) => {
   const [isBlocked, setIsBlocked] = useState(false);
 
   useEffect(() => {
-    const betaEnabled = true;
+    const betaEnabled = configData.BETA_ENABLED;
     if (betaEnabled) return;
 
     const hostname = window.location.hostname;
@@ -104,7 +105,7 @@ const BetaRedirect = ({ children }: { children: React.ReactNode }) => {
 
     if (isBetaHost) {
       const betaCode = localStorage.getItem('beta_code');
-      const expectedCode = process.env.NEXT_PUBLIC_BETA_CODE;
+      const expectedCode = configData.BETA_CODE;
       if (betaCode !== expectedCode) {
         setIsBlocked(true);
       }


### PR DESCRIPTION
## Summary
- Define `BETA_ENABLED` and `BETA_CODE` in `data/config.json`
- Source beta flags from the shared config in `next.config.ts`
- Client layout pulls beta access and code from the config

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b15d1d80f4832aa33d2d2587df9e15