### PR TITLE
Copy data directory before dev and build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+# Make sure /public/data exists before copying
+RUN mkdir -p /app/public/data
+
 # Copy built assets from the builder stage
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/data ./data

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# Make sure /public/data exists before copying
-RUN mkdir -p /app/public/data
-
 # Copy built assets from the builder stage
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/data ./data

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,4 @@
 import type { NextConfig } from 'next';
-import CopyWebpackPlugin from 'copy-webpack-plugin';
-import path from 'path';
 
 const nextConfig: NextConfig = {
   typescript: {
@@ -10,21 +8,6 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   env: {},
-  webpack: (config) => {
-    config.plugins = config.plugins || [];
-    config.plugins.push(
-      new CopyWebpackPlugin({
-        patterns: [
-          {
-            from: path.resolve(__dirname, 'data'),
-            to: path.resolve(__dirname, 'public/data'),
-          },
-        ],
-      })
-    );
-
-    return config;
-  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
         "@types/node": "^20",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "copy-webpack-plugin": "^13.0.1",
         "eslint": "9.34.0",
         "eslint-config-next": "15.5.0",
         "genkit-cli": "^1.14.1",
@@ -7806,30 +7805,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-    },
-    "node_modules/copy-webpack-plugin": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-13.0.1.tgz",
-      "integrity": "sha512-J+YV3WfhY6W/Xf9h+J1znYuqTye2xkBUIGyTPWuBAT27qajBa5mR4f8WBmfDY3YjRftT2kqZZiLi1qf0H+UOFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob-parent": "^6.0.1",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^4.2.0",
-        "serialize-javascript": "^6.0.2",
-        "tinyglobby": "^0.2.12"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      }
     },
     "node_modules/cors": {
       "version": "2.8.5",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "3.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 9002",
+    "dev": "node scripts/copy-data.js && next dev --turbopack -p 9002",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
-    "build": "next build",
+    "build": "node scripts/copy-data.js && next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"
@@ -73,7 +73,6 @@
     "@types/node": "^20",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "copy-webpack-plugin": "^13.0.1",
     "eslint": "9.34.0",
     "eslint-config-next": "15.5.0",
     "genkit-cli": "^1.14.1",

--- a/scripts/copy-data.js
+++ b/scripts/copy-data.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.resolve(__dirname, '..', 'data');
+const destDir = path.resolve(__dirname, '..', 'public', 'data');
+
+fs.rmSync(destDir, { recursive: true, force: true });
+fs.cpSync(srcDir, destDir, { recursive: true });
+
+console.log(`Copied data from ${srcDir} to ${destDir}`);
+

--- a/scripts/copy-data.js
+++ b/scripts/copy-data.js
@@ -4,6 +4,8 @@ const path = require('path');
 const srcDir = path.resolve(__dirname, '..', 'data');
 const destDir = path.resolve(__dirname, '..', 'public', 'data');
 
+console.log(`Copying data from ${srcDir} to ${destDir}`);
+
 fs.rmSync(destDir, { recursive: true, force: true });
 fs.cpSync(srcDir, destDir, { recursive: true });
 


### PR DESCRIPTION
## Summary
- remove predev/prebuild hooks and copy data within dev and build scripts
- run `scripts/copy-data.js` before starting Next.js dev and build commands

## Testing
- `npm run dev -- --help`
- `npm run build -- --help`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1bea4f2d0832a84a1884e8b196fd2