### PR TITLE
Replace Matomo integration with matomo-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ To get a local copy up and running, follow these simple steps.
     ```sh
     npm install
     ```
-4.  Create a `.env` file in the root of the project and add your Discord Webhook URL:
+4.  Create a `.env` file in the root of the project and add your Discord Webhook URL and Matomo settings:
     ```
     DISCORD_WEBHOOK_URL=your_webhook_url_here
+    NEXT_PUBLIC_MATOMO_URL=https://your-matomo-domain.example/
+    NEXT_PUBLIC_MATOMO_SITE_ID=1
     ```
+    * `NEXT_PUBLIC_MATOMO_URL` should point to your Matomo server and end with a trailing slash.
+    * `NEXT_PUBLIC_MATOMO_SITE_ID` must match the site ID configured in that Matomo instance.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "leaflet-freedraw": "^2.14.0",
     "leaflet-search": "^4.0.0",
     "lucide-react": "^0.475.0",
+    "@socialgouv/matomo-next": "^2.0.0",
     "next": "15.3.3",
     "next-themes": "^0.4.6",
     "patch-package": "^8.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,8 +7,8 @@ import path from 'path';
 import FullScreenMessage from '@/components/layout/maintenance-page';
 import { Footer } from '@/components/layout/footer';
 import { Layout } from '@/components/layout/layout';
-import Script from 'next/script';
 import { ClientLayout } from '@/components/layout/client-layout';
+import { Matomo } from '@/components/matomo';
 
 type SiteConfig = {
   SITE_LIVE: boolean;
@@ -116,23 +116,6 @@ function ExtraHead() {
         color="#e2b055"
       />
 
-      {/* Matomo tracking (prod only) */}
-      {process.env.NODE_ENV === 'production' && (
-        <Script id="matomo-tracking" strategy="afterInteractive">
-          {`
-            var _paq = window._paq = window._paq || [];
-            _paq.push(['trackPageView']);
-            _paq.push(['enableLinkTracking']);
-            (function() {
-              var u="//sys.booskit.dev/analytics/";
-              _paq.push(['setTrackerUrl', u+'matomo.php']);
-              _paq.push(['setSiteId', '1']);
-              var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-              g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-            })();
-          `}
-        </Script>
-      )}
     </head>
   );
 }
@@ -179,6 +162,7 @@ export default async function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <Matomo />
           <ClientLayout
             cacheVersion={config.CACHE_VERSION}
             localStorageVersion={config.LOCAL_STORAGE_VERSION}

--- a/src/components/matomo.tsx
+++ b/src/components/matomo.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { init } from '@socialgouv/matomo-next';
+
+export function Matomo() {
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV === 'production' &&
+      process.env.NEXT_PUBLIC_MATOMO_URL &&
+      process.env.NEXT_PUBLIC_MATOMO_SITE_ID
+    ) {
+      init({
+        url: process.env.NEXT_PUBLIC_MATOMO_URL,
+        siteId: process.env.NEXT_PUBLIC_MATOMO_SITE_ID,
+      });
+    }
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary
- remove inline Matomo tracking script
- initialize Matomo using `@socialgouv/matomo-next`
- document required Matomo environment variables

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@socialgouv%2fmatomo-next)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cc57b334832aafd1de66ed049d57