### PR TITLE
Track Matomo page views on route change

### DIFF
--- a/src/components/matomo.tsx
+++ b/src/components/matomo.tsx
@@ -3,9 +3,13 @@
 
 import { useEffect } from 'react';
 import { init } from '@socialgouv/matomo-next';
+import { usePathname, useSearchParams } from 'next/navigation';
 import analyticsConfig from '../../data/analytics.json';
 
 export function Matomo() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
   useEffect(() => {
     if (
       process.env.NODE_ENV === 'production' &&
@@ -18,5 +22,20 @@ export function Matomo() {
       });
     }
   }, []);
+
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV === 'production' &&
+      analyticsConfig.ANALYTICS_URL &&
+      analyticsConfig.ANALYTICS_TRACKER_ID &&
+      pathname
+    ) {
+      const url = `${pathname}${searchParams ? `?${searchParams.toString()}` : ''}`;
+      const _paq = (window as any)._paq || [];
+      _paq.push(['setCustomUrl', url]);
+      _paq.push(['trackPageView']);
+    }
+  }, [pathname, searchParams]);
+
   return null;
 }


### PR DESCRIPTION
## Summary
- track Matomo page views when route changes

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b1d9789a30832ab4d2e91e1ab85af5