### PR TITLE
Ensure max time per charge is at least its minimum time

### DIFF
--- a/src/components/arrest-calculator/arrest-calculator-results.tsx
+++ b/src/components/arrest-calculator/arrest-calculator-results.tsx
@@ -189,12 +189,15 @@ export function ArrestCalculatorResults({
           return fineObj[row.offense!] || 0;
         }
     
-        const originalMinTime = getTime(chargeDetails.time);
-        const originalMaxTime = getTime(chargeDetails.maxtime);
+        const originalMinTime = formatTimeInMinutes(getTime(chargeDetails.time));
+        let originalMaxTime = formatTimeInMinutes(getTime(chargeDetails.maxtime));
+        if (originalMaxTime < originalMinTime) {
+          originalMaxTime = originalMinTime;
+        }
         const originalPoints = chargeDetails.points?.[row.class as keyof typeof chargeDetails.points] ?? 0;
-    
-        const modifiedMinTime = formatTimeInMinutes(originalMinTime) * sentenceMultiplier;
-        const modifiedMaxTime = formatTimeInMinutes(originalMaxTime) * sentenceMultiplier;
+
+        const modifiedMinTime = originalMinTime * sentenceMultiplier;
+        const modifiedMaxTime = originalMaxTime * sentenceMultiplier;
         const modifiedPoints = originalPoints * pointsMultiplier;
     
         const fine = getFine(chargeDetails.fine);
@@ -212,8 +215,8 @@ export function ArrestCalculatorResults({
           additionDetails,
           isModified: sentenceMultiplier !== 1 || pointsMultiplier !== 1,
           original: {
-            minTime: formatTimeInMinutes(originalMinTime),
-            maxTime: formatTimeInMinutes(originalMaxTime),
+            minTime: originalMinTime,
+            maxTime: originalMaxTime,
             points: originalPoints,
           },
           modified: {
@@ -264,10 +267,6 @@ export function ArrestCalculatorResults({
         }
       );
     
-      if (totals.modified.minTime > totals.modified.maxTime) {
-        totals.modified.maxTime = totals.modified.minTime;
-      }
-      
       const getBailStatus = () => {
         if (!totals.bailStatus.hasBailCharge) return 'N/A';
         if (totals.bailStatus.noBail) return 'NOT ELIGIBLE';

--- a/src/components/arrest-report/arrest-report-page.tsx
+++ b/src/components/arrest-report/arrest-report-page.tsx
@@ -190,9 +190,14 @@ export function ArrestReportPage() {
     
           const minTime = getTime(chargeDetails.time);
           const maxTime = getTime(chargeDetails.maxtime);
-    
-          acc.minTime += formatTimeInMinutes(minTime);
-          acc.maxTime += formatTimeInMinutes(maxTime);
+          const minTimeMinutes = formatTimeInMinutes(minTime);
+          let maxTimeMinutes = formatTimeInMinutes(maxTime);
+          if (maxTimeMinutes < minTimeMinutes) {
+            maxTimeMinutes = minTimeMinutes;
+          }
+
+          acc.minTime += minTimeMinutes;
+          acc.maxTime += maxTimeMinutes;
           acc.points += chargeDetails.points?.[row.class as keyof typeof chargeDetails.points] ?? 0;
           acc.fine += getFine(chargeDetails.fine);
           
@@ -285,18 +290,21 @@ export function ArrestReportPage() {
                             const typePrefix = `${chargeDetails.type}${row.class}`;
                             const title = `${typePrefix} ${chargeDetails.id}. ${chargeDetails.charge}${row.offense !== '1' ? ` (Offence #${row.offense})` : ''}`;
                             
-                            const getTime = (timeObj: any, simple = false) => {
-                                if(!timeObj) return 'N/A';
-                                let timeValue;
+                            const getTimeValue = (timeObj: any) => {
+                                if(!timeObj) return { days: 0, hours: 0, min: 0 };
                                 if (isDrugCharge && row.category) {
-                                    timeValue = timeObj[row.category];
-                                } else {
-                                    timeValue = timeObj;
+                                    return timeObj[row.category] || { days: 0, hours: 0, min: 0 };
                                 }
-                                return simple ? formatTimeSimple(timeValue) : formatTime(timeValue);
+                                return timeObj;
                             }
-                            const minTime = getTime(chargeDetails.time, true);
-                            const maxTime = getTime(chargeDetails.maxtime, true);
+                            const minTimeObj = getTimeValue(chargeDetails.time);
+                            const maxTimeObj = getTimeValue(chargeDetails.maxtime);
+                            let adjustedMaxTimeObj = maxTimeObj;
+                            if (formatTimeInMinutes(maxTimeObj) < formatTimeInMinutes(minTimeObj)) {
+                                adjustedMaxTimeObj = minTimeObj;
+                            }
+                            const minTime = formatTimeSimple(minTimeObj);
+                            const maxTime = formatTimeSimple(adjustedMaxTimeObj);
 
                             const getFine = (fineObj: any) => {
                                 if (!fineObj) return '$0';

--- a/src/components/arrest-report/basic-formatted-report.tsx
+++ b/src/components/arrest-report/basic-formatted-report.tsx
@@ -74,8 +74,15 @@ export function BasicFormattedReport({ formData, report, penalCode, innerRef }: 
               return fineObj[row.offense!] || 0;
             }
       
-            acc.minTime += formatTimeInMinutes(getTime(chargeDetails.time));
-            acc.maxTime += formatTimeInMinutes(getTime(chargeDetails.maxtime));
+            const minTime = getTime(chargeDetails.time);
+            const maxTime = getTime(chargeDetails.maxtime);
+            const minTimeMinutes = formatTimeInMinutes(minTime);
+            let maxTimeMinutes = formatTimeInMinutes(maxTime);
+            if (maxTimeMinutes < minTimeMinutes) {
+              maxTimeMinutes = minTimeMinutes;
+            }
+            acc.minTime += minTimeMinutes;
+            acc.maxTime += maxTimeMinutes;
             acc.fine += getFine(chargeDetails.fine);
             acc.points += chargeDetails.points?.[row.class as keyof typeof chargeDetails.points] ?? 0;
             


### PR DESCRIPTION
## Summary
- fix arrest calculator to apply min-to-max correction per charge
- adjust arrest reports to mirror per-charge max time logic

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2f12f5f8c832a8c9e1838e00426a5