### PR TITLE
feat: enhance changelog page with filters

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -4,6 +4,8 @@
             "version": "3.1.6_05",
             "type": "Hotfix",
             "date": "2025-08-30",
+            "cacheVersion": "5",
+            "localStorageVersion": "2",
             "items": [
                 {
                 "type": "backend",

--- a/src/app/area51/page.tsx
+++ b/src/app/area51/page.tsx
@@ -23,6 +23,8 @@ type ChangelogEntry = {
     version: string;
     type: 'Release' | 'Major Update' | 'Minor Update' | 'Hotfix';
     date: string;
+    cacheVersion?: string;
+    localStorageVersion?: string;
     items: ChangelogItem[];
 };
 

--- a/src/components/changelog/changelog-page.tsx
+++ b/src/components/changelog/changelog-page.tsx
@@ -1,10 +1,12 @@
 
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { PageHeader } from '@/components/dashboard/page-header';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Wrench, PlusCircle, Pencil, GitCommit, Server } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
@@ -19,6 +21,8 @@ type ChangelogEntry = {
     version: string;
     type: 'Release' | 'Major Update' | 'Minor Update' | 'Hotfix';
     date: string;
+    cacheVersion?: string;
+    localStorageVersion?: string;
     items: ChangelogItem[];
 };
 
@@ -64,9 +68,25 @@ const changelogTypeColors = {
 const typeOrder = ['feature', 'addition', 'modification', 'backend', 'fix'];
 
 export function ChangelogPage({ initialChangelogs }: ChangelogPageProps) {
+    const [search, setSearch] = useState('');
+    const [typeFilter, setTypeFilter] = useState<string>('all');
+
     const sortedChangelogs = useMemo(() => {
         return [...initialChangelogs].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
     }, [initialChangelogs]);
+
+    const filteredChangelogs = useMemo(() => {
+        const lower = search.toLowerCase();
+        return sortedChangelogs.filter(entry => {
+            const matchesSearch =
+                !search ||
+                entry.version.toLowerCase().includes(lower) ||
+                entry.type.toLowerCase().includes(lower) ||
+                entry.items.some(item => item.description.toLowerCase().includes(lower));
+            const matchesType = typeFilter === 'all' || entry.type === typeFilter;
+            return matchesSearch && matchesType;
+        });
+    }, [sortedChangelogs, search, typeFilter]);
 
     return (
         <div className="container mx-auto p-4 md:p-6 lg:p-8">
@@ -75,13 +95,59 @@ export function ChangelogPage({ initialChangelogs }: ChangelogPageProps) {
                 description="Tracking all the changes, features, and fixes."
             />
 
-            <div className="relative pl-6 before:absolute before:inset-y-0 before:left-6 before:w-px before:bg-border">
-                {sortedChangelogs.map((changelog, index) => (
+            <Card className="mb-8">
+                <CardHeader>
+                    <CardTitle>How the changelog works</CardTitle>
+                    <CardDescription>Release tags help identify the scope of a version.</CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-4 sm:grid-cols-2 md:grid-cols-4">
+                    <div className="flex items-center gap-2">
+                        <Badge variant="outline" className={cn(changelogTypeColors['Release'])}>Release</Badge>
+                        <span className="text-sm text-muted-foreground">Stable production version.</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Badge variant="outline" className={cn(changelogTypeColors['Major Update'])}>Major</Badge>
+                        <span className="text-sm text-muted-foreground">Large feature changes.</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Badge variant="outline" className={cn(changelogTypeColors['Minor Update'])}>Minor</Badge>
+                        <span className="text-sm text-muted-foreground">Smaller improvements.</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Badge variant="outline" className={cn(changelogTypeColors['Hotfix'])}>Hotfix</Badge>
+                        <span className="text-sm text-muted-foreground">Urgent fixes.</span>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-center">
+                <Input
+                    placeholder="Search changelog..."
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    className="md:max-w-xs"
+                />
+                <Select value={typeFilter} onValueChange={setTypeFilter}>
+                    <SelectTrigger className="w-full md:w-48">
+                        <SelectValue placeholder="Filter type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="all">All Types</SelectItem>
+                        <SelectItem value="Release">Release</SelectItem>
+                        <SelectItem value="Major Update">Major Update</SelectItem>
+                        <SelectItem value="Minor Update">Minor Update</SelectItem>
+                        <SelectItem value="Hotfix">Hotfix</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+
+            <div className="relative pl-6 before:absolute before:inset-y-0 before:left-6 before:w-px before:bg-gradient-to-b before:from-border before:to-transparent">
+                {filteredChangelogs.map((changelog) => (
                     <div key={changelog.version} className="relative mb-8 pl-8">
-                         <div className="absolute -left-1 top-1.5 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                        <div className="absolute -left-1 top-1.5 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground ring-4 ring-background">
                             <GitCommit className="h-5 w-5" />
                         </div>
-                        <Card>
+                        <Card className="shadow-sm">
                             <CardHeader>
                                 <div className="flex flex-wrap items-center justify-between gap-2">
                                     <div>
@@ -97,22 +163,30 @@ export function ChangelogPage({ initialChangelogs }: ChangelogPageProps) {
                             </CardHeader>
                             <CardContent>
                                 <ul className="space-y-4">
-                                    {[...changelog.items].sort((a, b) => typeOrder.indexOf(a.type) - typeOrder.indexOf(b.type)).map((item, itemIndex) => {
-                                        const details = itemTypeDetails[item.type];
-                                        const Icon = details.icon;
-                                        return (
-                                            <li key={`${changelog.version}-${itemIndex}`} className="flex items-start gap-4">
-                                                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-secondary shrink-0">
-                                                    <Icon className={cn("h-5 w-5", details.color)} />
-                                                </div>
-                                                <div>
-                                                    <p className="font-semibold">{details.label}</p>
-                                                    <p className="text-muted-foreground" dangerouslySetInnerHTML={{ __html: item.description }} />
-                                                </div>
-                                            </li>
-                                        );
-                                    })}
+                                    {[...changelog.items]
+                                        .sort((a, b) => typeOrder.indexOf(a.type) - typeOrder.indexOf(b.type))
+                                        .map((item, itemIndex) => {
+                                            const details = itemTypeDetails[item.type];
+                                            const Icon = details.icon;
+                                            return (
+                                                <li key={`${changelog.version}-${itemIndex}`} className="flex items-start gap-4">
+                                                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-secondary shrink-0">
+                                                        <Icon className={cn("h-5 w-5", details.color)} />
+                                                    </div>
+                                                    <div>
+                                                        <p className="font-semibold">{details.label}</p>
+                                                        <p className="text-muted-foreground" dangerouslySetInnerHTML={{ __html: item.description }} />
+                                                    </div>
+                                                </li>
+                                            );
+                                        })}
                                 </ul>
+                                {(changelog.cacheVersion || changelog.localStorageVersion) && (
+                                    <div className="mt-4 space-y-1 text-sm text-muted-foreground">
+                                        {changelog.cacheVersion && <p>Cache Version: {changelog.cacheVersion}</p>}
+                                        {changelog.localStorageVersion && <p>Local Storage Version: {changelog.localStorageVersion}</p>}
+                                    </div>
+                                )}
                             </CardContent>
                         </Card>
                     </div>


### PR DESCRIPTION
## Summary
- add explanatory release tag overview
- support search and release type filtering for changelog
- show cache/localStorage versions when provided

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b45c791374832ab27483653fccfb14