### PR TITLE
feat: expand offense handling up to five levels

### DIFF
--- a/data/paperwork-generators/parking-ticket.json
+++ b/data/paperwork-generators/parking-ticket.json
@@ -51,9 +51,10 @@
         },
         { "type": "section", "title": "Charges" },
         { 
-            "type": "charge", 
+            "type": "charge",
             "name": "charges",
             "showClass": false,
+            "showOffense": true,
             "allowedTypes": { "I": true },
             "customFields": [
                 {

--- a/data/paperwork-generators/traffic-report.json
+++ b/data/paperwork-generators/traffic-report.json
@@ -63,9 +63,10 @@
         ]},
         { "type": "section", "title": "Charges" },
         { 
-            "type": "charge", 
+            "type": "charge",
             "name": "charges",
             "showClass": true,
+            "showOffense": true,
             "allowedTypes": { "M": true, "I": true },
             "allowedIds": "401-433",
             "customFields": [

--- a/src/components/arrest-calculator/arrest-calculator-page.tsx
+++ b/src/components/arrest-calculator/arrest-calculator-page.tsx
@@ -197,6 +197,8 @@ export function ArrestCalculatorPage() {
     if (chargeDetails.offence?.['1']) defaultOffense = '1';
     else if (chargeDetails.offence?.['2']) defaultOffense = '2';
     else if (chargeDetails.offence?.['3']) defaultOffense = '3';
+    else if (chargeDetails.offence?.['4']) defaultOffense = '4';
+    else if (chargeDetails.offence?.['5']) defaultOffense = '5';
   
     updateCharge(chargeRow.uniqueId, {
       chargeId: chargeId,
@@ -400,6 +402,18 @@ export function ArrestCalculatorPage() {
                         disabled={!chargeDetails?.offence['3']}
                       >
                         Offense #3
+                      </SelectItem>
+                      <SelectItem
+                        value="4"
+                        disabled={!chargeDetails?.offence['4']}
+                      >
+                        Offense #4
+                      </SelectItem>
+                      <SelectItem
+                        value="5"
+                        disabled={!chargeDetails?.offence['5']}
+                      >
+                        Offense #5
                       </SelectItem>
                     </SelectContent>
                   </Select>

--- a/src/stores/charge-store.ts
+++ b/src/stores/charge-store.ts
@@ -9,7 +9,7 @@ export interface Charge {
   charge: string;
   type: 'F' | 'M' | 'I' | '?';
   class: { A: boolean; B: boolean; C: boolean };
-  offence: { '1': boolean; '2': boolean; '3': boolean };
+  offence: { '1': boolean; '2': boolean; '3': boolean; '4': boolean; '5': boolean };
   time: any;
   maxtime: any;
   points: any;


### PR DESCRIPTION
## Summary
- extend charge model to handle five offenses
- show up to five offense options in arrest calculator and paperwork forms
- update paperwork previews to reflect selected offense

## Testing
- no tests due to instructions

------
https://chatgpt.com/codex/tasks/task_e_68b6e0b660e4832a97ce9a07b4346605