### PR TITLE
feat: add dynamic page titles

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,10 @@ export async function generateMetadata(): Promise<Metadata> {
   const config: SiteConfig = JSON.parse(file);
 
   return {
-    title: config.SITE_NAME,
+    title: {
+      default: 'MDC Panel',
+      template: `${config.SITE_NAME} - %s`,
+    },
     description: config.SITE_DESCRIPTION,
     keywords: [
       'booskit','booskit.dev','MDC','MDC Panel','Mobile','Data','Computer','Panel',
@@ -54,6 +57,7 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title: config.SITE_NAME,
       description: config.SITE_DESCRIPTION,
+      siteName: config.SITE_NAME,
       type: 'website',
       images: config.SITE_IMAGE
         ? [

--- a/src/app/paperwork-generators/builder/page.tsx
+++ b/src/app/paperwork-generators/builder/page.tsx
@@ -1,6 +1,7 @@
 import { PaperworkGeneratorBuilder } from '@/components/paperwork-generators/paperwork-generator-builder';
 import { promises as fs } from 'fs';
 import path from 'path';
+import type { Metadata } from 'next';
 
 async function getConfig() {
     const configPath = path.join(process.cwd(), 'data/config.json');
@@ -28,3 +29,7 @@ export default async function PaperworkGeneratorBuilderPage() {
       <PaperworkGeneratorBuilder />
   );
 }
+
+export const metadata: Metadata = {
+  title: 'Form Builder',
+};

--- a/src/app/paperwork-generators/form/page.tsx
+++ b/src/app/paperwork-generators/form/page.tsx
@@ -35,15 +35,21 @@ function GeneratorPageContent() {
                 }
                 return response.json();
             })
-            .then(data => {
-                setGeneratorConfig(data);
-                setLoading(false);
-            })
-            .catch(() => {
-                setError(true);
-                setLoading(false);
-            });
-    }, [type, id, groupId]);
+              .then(data => {
+                  setGeneratorConfig(data);
+                  setLoading(false);
+              })
+              .catch(() => {
+                  setError(true);
+                  setLoading(false);
+              });
+      }, [type, id, groupId]);
+
+      useEffect(() => {
+          if (generatorConfig?.title) {
+              document.title = `MDC Panel+ - ${generatorConfig.title}`;
+          }
+      }, [generatorConfig]);
 
     if (loading) {
         return (

--- a/src/app/paperwork-generators/page.tsx
+++ b/src/app/paperwork-generators/page.tsx
@@ -11,6 +11,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Badge } from '@/components/ui/badge';
 import { PaperworkGeneratorsList } from '@/components/paperwork-generators/paperwork-generators-list';
 import { Separator } from '@/components/ui/separator';
+import type { Metadata } from 'next';
 
 async function getPaperworkData() {
     const baseDir = path.join(process.cwd(), 'data/paperwork-generators');
@@ -177,3 +178,7 @@ export default async function PaperworkGeneratorsPage() {
       </div>
   );
 }
+
+export const metadata: Metadata = {
+  title: 'Paperwork Generators',
+};

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 import { SettingsPage } from '@/components/settings/settings-page';
 import { promises as fs } from 'fs';
 import path from 'path';
+import type { Metadata } from 'next';
 
 async function getFactionGroups() {
     const baseDir = path.join(process.cwd(), 'data/paperwork-generators');
@@ -34,3 +35,7 @@ export default async function Settings() {
       <SettingsPage initialFactionGroups={factionGroups} />
   );
 }
+
+export const metadata: Metadata = {
+  title: 'Settings',
+};


### PR DESCRIPTION
## Summary
- add global title template and OpenGraph siteName for Discord embeds
- set metadata titles for settings and paperwork generator pages
- update paperwork generator forms to reflect generator titles

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Type 'string | undefined' is not assignable to type 'string', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b81b406a38832a9834dc734c471eb3