### PR TITLE
Potential fix for code scanning alert no. 5: Prototype-polluting function

### DIFF
--- a/src/components/paperwork-generators/paperwork-generator-form.tsx
+++ b/src/components/paperwork-generators/paperwork-generator-form.tsx
@@ -123,6 +123,9 @@ const setValueAtPath = (target: Record<string, any>, path: string[], value: any)
 
 const mergeDeep = (target: Record<string, any>, source: Record<string, any>): Record<string, any> => {
     Object.entries(source).forEach(([key, value]) => {
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+            return;
+        }
         if (value && typeof value === 'object' && !Array.isArray(value)) {
             if (!target[key] || typeof target[key] !== 'object' || Array.isArray(target[key])) {
                 target[key] = {};


### PR DESCRIPTION
Potential fix for [https://github.com/b00skit/MDC-Panel-plus/security/code-scanning/5](https://github.com/b00skit/MDC-Panel-plus/security/code-scanning/5)

To fix the vulnerability, we must ensure that `mergeDeep` does not assign to special keys that could lead to prototype pollution, specifically `__proto__`, `prototype`, and `constructor`. We should skip any property with these names during merge. The best fix is to add a guard at the top of the loop in `mergeDeep`—inside the `.forEach()` callback—to skip processing if the key is one of these values. This fix is localized, carries no unintended side effects, and does not change existing (legitimate) functionality. No new imports are necessary. Only the `mergeDeep` function (lines 124–136) need to be touched in `src/components/paperwork-generators/paperwork-generator-form.tsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
